### PR TITLE
Feature/add prompt loop

### DIFF
--- a/includes/minishell_tnishina.h
+++ b/includes/minishell_tnishina.h
@@ -1,4 +1,34 @@
 #ifndef MINISHELL_TNISHINA_H
 # define MINISHELL_TNISHINA_H
 
+/*
+** basic parameters for minishell
+*/
+
+# define PROMPT "minishell$ "
+# define EXIT_PROMPT "exit\n"
+
+/*
+** basic GNL parameters
+*/
+
+# define MAX_FD 256
+# define BUFFER_SIZE 1024
+# define GNL_SUCCESS 1
+# define GNL_ERROR -1
+# define GNL_EOF 0
+
+/*
+** required header files
+*/
+
+# include <stdio.h>
+# include <sys/wait.h>
+# include <unistd.h>
+# include <unistd.h>
+# include <string.h>
+
+int		get_next_line(int fd, char **line);
+void	ft_free_str(char **str);
+
 #endif

--- a/libft/ft_strchr.c
+++ b/libft/ft_strchr.c
@@ -6,7 +6,7 @@
 /*   By: tnishina <tnishina@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/11/03 11:47:38 by tnishina          #+#    #+#             */
-/*   Updated: 2021/02/27 18:17:55 by tnishina         ###   ########.fr       */
+/*   Updated: 2021/02/28 10:50:49 by tnishina         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,8 @@
 char
 	*ft_strchr(const char *s, int c)
 {
+	if (!s)
+		return (NULL);
 	while (*s)
 	{
 		if (*s == (const char)c)

--- a/srcs/get_next_line.c
+++ b/srcs/get_next_line.c
@@ -1,0 +1,87 @@
+#include "minishell_tnishina.h"
+#include "libft.h"
+
+void
+	ft_free_str(char **str)
+{
+	free(*str);
+	*str = NULL;
+}
+
+static int
+	set_line(char **line, char **fd_array, char *find)
+{
+	int		res;
+	char	*tmp;
+
+	res = GNL_SUCCESS;
+	if (find)
+	{
+		tmp = *fd_array;
+		*line = ft_substr(*fd_array, 0, find - *fd_array);
+		if (!(*fd_array = ft_strdup(find + 1)))
+			res = GNL_ERROR;
+		ft_free_str(&tmp);
+	}
+	else
+	{
+		*line = ft_strdup(*fd_array);
+		ft_free_str(fd_array);
+		res = GNL_EOF;
+	}
+	if (!(*line) || res == GNL_ERROR)
+	{
+		ft_free_str(line);
+		ft_free_str(fd_array);
+		res = GNL_ERROR;
+	}
+	return (res);
+}
+
+static void
+	read_file(int fd, char **fd_array, char **buff, char **find)
+{
+	char	*tmp;
+	ssize_t	read_count;
+
+	while ((read_count = read(fd, *buff, BUFFER_SIZE)) >= 0)
+	{
+		(*buff)[read_count] = '\0';
+		if (*fd_array)
+		{
+			tmp = *fd_array;
+			*fd_array = ft_strjoin(*fd_array, *buff);
+			ft_free_str(&tmp);
+		}
+		else
+			*fd_array = ft_strdup(*buff);
+		if ((*find = ft_strchr(*fd_array, '\n')) || !read_count || !*fd_array)
+			break ;
+	}
+}
+
+int
+	get_next_line(int fd, char **line)
+{
+	static char	*fd_array[MAX_FD];
+	char		*buff;
+	char		*find;
+
+	if (fd < 0 || MAX_FD <= fd)
+		return (GNL_ERROR);
+	if (line)
+		*line = NULL;
+	buff = (char *)malloc(sizeof(char) * (BUFFER_SIZE + 1));
+	if (!line || !buff || read(fd, buff, 0) < 0)
+	{
+		ft_free_str(&buff);
+		ft_free_str(&fd_array[fd]);
+		return (GNL_ERROR);
+	}
+	if (!(find = ft_strchr(fd_array[fd], '\n')))
+		read_file(fd, &fd_array[fd], &buff, &find);
+	ft_free_str(&buff);
+	if (!fd_array[fd])
+		return (GNL_ERROR);
+	return (set_line(line, &fd_array[fd], find));
+}

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -14,10 +14,10 @@ int
 void
 	do_command(char *line)
 {
-	char	*argv[2];
+	char	**argv;
 
-	argv[0] = ft_strjoin("/bin/", line);
-	argv[1] = NULL;
+	argv = ft_split(line, ' ');
+	argv[0] = ft_strjoin("/bin/", argv[0]);
 	execve(argv[0], argv, environ);
 	exit_with_error("execve");
 }

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -1,5 +1,47 @@
+#include "minishell_tnishina.h"
+#include "libft.h"
+
+// need to use g_* prefix to pass norm
+extern char **environ;
+
+int
+	exit_with_error(char *str)
+{
+	printf("%s: %s\n", str, strerror(errno));
+	exit(1);
+}
+
+void
+	do_command(char *line)
+{
+	char	*argv[2];
+
+	argv[0] = ft_strjoin("/bin/", line);
+	argv[1] = NULL;
+	execve(argv[0], argv, environ);
+	exit_with_error("execve");
+}
+
 int
 	main(void)
 {
-	return (0);
+	char	*line;
+	pid_t	pid;
+	int		status;
+
+	write(STDOUT_FILENO, PROMPT, ft_strlen(PROMPT));
+	while (get_next_line(STDIN_FILENO, &line) == 1 &&
+		ft_strncmp(line, "exit", 5))
+	{
+		if ((pid = fork()) < 0)
+			exit_with_error("fork");
+		else if (pid == 0)
+			do_command(line);
+		if ((pid = waitpid(pid, &status, 0)) < 0)
+			exit_with_error("wait");
+		ft_free_str(&line);
+		write(STDOUT_FILENO, PROMPT, ft_strlen(PROMPT));
+	}
+	write(STDOUT_FILENO, EXIT_PROMPT, ft_strlen(EXIT_PROMPT));
+	exit(0);
 }


### PR DESCRIPTION
※splitの部分を追加したので、再度プルリクをお送りします。
# 概要
以下の部分を作成。
- main関数の部分のプロンプトのループ
- GNLを使った標準入力の読み込み
- ls/pwd/echo/exit/bashあたりのコマンドはシンプルな引数であれば普通に動かせそうですが、まだそこまで丁寧にエラーチェックはしていないです

# 受入条件
内容確認して頂き、ローカルでも動作確認頂けるとありがたいです。

# コメント
- 自分がローカルでコンパイルした際には、libftをmakeしたあと、下記のコマンドを実行しています
gcc -g -I./includes -I./libft srcs/minishell.c srcs/get_next_line.c libft/libft.a -o minishell
- GNLの中でft_strchrを使う際に、第一引数のnull判定がついていないとうまく動かなかったので修正しました
- グローバル変数はnorm的にはg_の接頭辞をつけなければいけないのですが、environにg_をつけるとうまく動かなくなってしまったので、一旦environのままにしています