### PR TITLE
add #6 cd function

### DIFF
--- a/cdtest.sh
+++ b/cdtest.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-make ../libft
-make clean ../libft
+cd libft
+make
+cd ..
 gcc -Wall -Wextra -Werror -I./includes -I./libft srcs/cd.c srcs/command_utils.c -Llibft -lft -D CDTEST -o cd.out
 echo "\x1b[33m./cd.out\x1b[0m"
 ./cd.out
@@ -18,8 +19,8 @@ echo "\x1b[33m./cd.out cd \$HOME\x1b[0m"
 echo "\x1b[33m./cd.out cd hoge\x1b[0m"
 ./cd.out cd hoge
 
-echo "\x1b[33m./cd.out mkdir test\x1b[0m"
-./cd.out mkdir test
+echo "\x1b[33mmkdir test\x1b[0m"
+mkdir test
 echo "\x1b[33m./cd.out cd test\x1b[0m"
 ./cd.out cd test
 

--- a/cdtest.sh
+++ b/cdtest.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+make ../libft
+make clean ../libft
+gcc -Wall -Wextra -Werror -I./includes -I./libft srcs/cd.c srcs/command_utils.c -Llibft -lft -D CDTEST -o cd.out
+echo "\x1b[33m./cd.out\x1b[0m"
+./cd.out
+
+echo "\x1b[33m./cd.out cd\x1b[0m"
+./cd.out cd
+
+echo "\x1b[33m./cd.out cd ~\x1b[0m"
+./cd.out cd ~
+
+echo "\x1b[33m./cd.out cd \$HOME\x1b[0m"
+./cd.out cd $HOME
+
+echo "\x1b[33m./cd.out cd hoge\x1b[0m"
+./cd.out cd hoge
+
+echo "\x1b[33m./cd.out mkdir test\x1b[0m"
+./cd.out mkdir test
+echo "\x1b[33m./cd.out cd test\x1b[0m"
+./cd.out cd test
+
+echo "\x1b[33m./cd.out cd hoge world\x1b[0m"
+./cd.out cd hoge world

--- a/includes/minishell_sikeda.h
+++ b/includes/minishell_sikeda.h
@@ -1,4 +1,19 @@
 #ifndef MINISHELL_SIKEDA_H
 # define MINISHELL_SIKEDA_H
 
+# include <unistd.h>
+# include <stdlib.h>
+# include <stdio.h>
+# include <sys/wait.h>
+# include <string.h>
+# include <errno.h>
+# include "libft.h"
+
+/*
+** command_utils.c
+*/
+int		ft_strcmp(const char *s1, const char *s2);
+void	ft_put_cmdmsg_fd(char *cmd_name, char *msg, int fd);
+void	ft_put_cmdmsg_fd_with_arg(char *cmd_name, char *msg, char *arg, int fd);
+
 #endif

--- a/includes/minishell_sikeda.h
+++ b/includes/minishell_sikeda.h
@@ -9,11 +9,13 @@
 # include <errno.h>
 # include "libft.h"
 
+# define PRG_NAME "minishell"
+
 /*
 ** command_utils.c
 */
 int		ft_strcmp(const char *s1, const char *s2);
-void	ft_put_cmdmsg_fd(char *cmd_name, char *msg, int fd);
-void	ft_put_cmdmsg_fd_with_arg(char *cmd_name, char *msg, char *arg, int fd);
+void	ft_put_cmderror(char *cmd_name, char *msg);
+void	ft_put_cmderror_with_arg(char *cmd_name, char *msg, char *arg);
 
 #endif

--- a/srcs/cd.c
+++ b/srcs/cd.c
@@ -1,0 +1,76 @@
+#include "minishell_sikeda.h"
+
+// debug
+int
+	lsh_launch(char **args)
+{
+	pid_t	pid;
+	pid_t	wpid;
+	int		status;
+
+	if ((pid = fork()) < 0)
+		perror("lsh");
+	if (pid == 0)
+	{
+		if (execvp(args[0], args) == -1)
+			perror("lsh");
+		exit(EXIT_FAILURE);
+	} else {
+		do
+		{
+			wpid = waitpid(pid, &status, WUNTRACED);
+		} while (!WIFEXITED(status) && !WIFSIGNALED(status));
+	}
+	return (1);
+}
+
+int
+	ft_cd(char **args)
+{
+	char	*debug_ls[] = {"pwd", NULL};
+	char	*path;
+
+	lsh_launch(debug_ls);
+	path = NULL;
+	if (args[1] == NULL)
+	{
+		// TODO: 引数なしでcdが呼ばれた際にパスを~にしてもHOMEへ行かない、課題範囲外なので引数エラーを返してしまっても良い、調査・検討する
+		path = "~";
+	}
+	else
+		path = args[1];
+	if (chdir(path) != 0)
+		ft_put_cmdmsg_fd_with_arg("cd", strerror(errno), args[1], STDERR_FILENO);
+	lsh_launch(debug_ls);
+	return (1);
+}
+
+#ifdef CDTEST
+int
+	main(int ac, char **av)
+{
+	char	**args;
+	int		ret;
+	int		i;
+
+	if (ac < 2)
+	{
+		ft_put_cmdmsg_fd("main", strerror(EINVAL), STDERR_FILENO);
+		return (EXIT_FAILURE);
+	}
+	if (!(args = (char **)malloc(sizeof(char*) * (ac + 1))))
+		return (EXIT_FAILURE);
+	i = -1;
+	while (++i < ac)
+		args[i] = av[i];
+	args[i] = NULL;
+	ret = 0;
+	if (!ft_strcmp(args[1], "cd"))
+		ret = ft_cd(++args);
+	if (!ret)
+	{
+		// TODO: exitが呼ばれたときに0が返されてloopを終了してmainが終了するイメージ
+	}
+	return (EXIT_SUCCESS);
+}
+#endif

--- a/srcs/cd.c
+++ b/srcs/cd.c
@@ -28,19 +28,12 @@ int
 	ft_cd(char **args)
 {
 	char	*debug_ls[] = {"pwd", NULL};
-	char	*path;
 
 	lsh_launch(debug_ls);
-	path = NULL;
 	if (args[1] == NULL)
-	{
-		// TODO: 引数なしでcdが呼ばれた際にパスを~にしてもHOMEへ行かない、課題範囲外なので引数エラーを返してしまっても良い、調査・検討する
-		path = "~";
-	}
-	else
-		path = args[1];
-	if (chdir(path) != 0)
-		ft_put_cmdmsg_fd_with_arg("cd", strerror(errno), args[1], STDERR_FILENO);
+		ft_put_cmderror("cd", strerror(EINVAL));
+	else if (chdir(args[1]) != 0)
+		ft_put_cmderror_with_arg("cd", strerror(errno), args[1]);
 	lsh_launch(debug_ls);
 	return (1);
 }
@@ -55,7 +48,7 @@ int
 
 	if (ac < 2)
 	{
-		ft_put_cmdmsg_fd("main", strerror(EINVAL), STDERR_FILENO);
+		ft_put_cmderror("main", strerror(EINVAL));
 		return (EXIT_FAILURE);
 	}
 	if (!(args = (char **)malloc(sizeof(char*) * (ac + 1))))

--- a/srcs/command_utils.c
+++ b/srcs/command_utils.c
@@ -14,19 +14,29 @@ int
 }
 
 void
-	ft_put_cmdmsg_fd(char *cmd_name, char *msg, int fd)
+	ft_put_cmderror(char *cmd_name, char *msg)
 {
+	int	fd;
+
+	fd = STDERR_FILENO;
+	ft_putstr_fd(PRG_NAME, fd);
+	ft_putstr_fd(": ", fd);
 	ft_putstr_fd(cmd_name, fd);
 	ft_putstr_fd(": ", fd);
 	ft_putendl_fd(msg, fd);
 }
 
 void
-	ft_put_cmdmsg_fd_with_arg(char *cmd_name, char *msg, char *arg, int fd)
+	ft_put_cmderror_with_arg(char *cmd_name, char *msg, char *arg)
 {
+	int	fd;
+
+	fd = STDERR_FILENO;
+	ft_putstr_fd(PRG_NAME, fd);
+	ft_putstr_fd(": ", fd);
 	ft_putstr_fd(cmd_name, fd);
 	ft_putstr_fd(": ", fd);
-	ft_putstr_fd(msg, fd);
+	ft_putstr_fd(arg, fd);
 	ft_putstr_fd(": ", fd);
-	ft_putendl_fd(arg, fd);
+	ft_putendl_fd(msg, fd);
 }

--- a/srcs/command_utils.c
+++ b/srcs/command_utils.c
@@ -1,0 +1,32 @@
+#include "minishell_sikeda.h"
+
+int
+	ft_strcmp(const char *s1, const char *s2)
+{
+	while (*s1 || *s2)
+	{
+		if (*s1 != *s2)
+			return (*(unsigned char *)s1 - *(unsigned char *)s2);
+		s1++;
+		s2++;
+	}
+	return (0);
+}
+
+void
+	ft_put_cmdmsg_fd(char *cmd_name, char *msg, int fd)
+{
+	ft_putstr_fd(cmd_name, fd);
+	ft_putstr_fd(": ", fd);
+	ft_putendl_fd(msg, fd);
+}
+
+void
+	ft_put_cmdmsg_fd_with_arg(char *cmd_name, char *msg, char *arg, int fd)
+{
+	ft_putstr_fd(cmd_name, fd);
+	ft_putstr_fd(": ", fd);
+	ft_putstr_fd(msg, fd);
+	ft_putstr_fd(": ", fd);
+	ft_putendl_fd(arg, fd);
+}


### PR DESCRIPTION
# 概要
cd 関数作成

# 受入条件
内容確認、動作確認、機能不備等は今後改良していければと思います

# コメント
- shell側の実装に合わせて変えた方が良いところがあればこれを叩き台にして改修していければと思います
- ./cdtest.shでコンパイルといくつかのテストを実行します
- 現状では今どのパスにいるのか分かりづらいので、pwdをcdコマンドの前後で呼ぶようにしています
- ./cdtest.shにより、cd.outが作成されるので ./cd.out cd srcs のように実行していただくと試せます
- 「// TODO: 引数なしでcdが呼ばれた際にパスを~にしてもHOMEへ行かない〜」の部分は一旦保留にしています
- 「// TODO: exitが呼ばれたときに0が返されてloopを終了してmainが終了するイメージ」はminishell.cのmainのwhileを止めるために0か1を各関数が返すイメージでいます。なのでft_cdの戻り値をintにしています。