### PR TITLE
add #34 pwd function

### DIFF
--- a/includes/minishell_sikeda.h
+++ b/includes/minishell_sikeda.h
@@ -27,12 +27,12 @@ char	*g_pwd;
 /*
 ** env_utils.c
 */
-char	*get_env_by_key(char *key, char **environ);
+char	*ft_getenv(const char *name);
 /*
 ** command_utils.c
 */
 int		ft_strcmp(const char *s1, const char *s2);
-char	*get_cmd_option(char *option, const char *arg);
+char	*ft_get_cmd_option(char *option, const char *arg);
 void	ft_put_cmderror(char *cmd_name, char *msg);
 void	ft_put_cmderror_with_arg(char *cmd_name, char *msg, char *arg);
 void	ft_put_cmderror_with_help(char *cmd_name, char *help);
@@ -43,7 +43,7 @@ int		ft_cd(char **args);
 /*
 ** pwd.c
 */
-int		init_pwd(char **environ);
+int		ft_init_pwd();
 int		ft_pwd(char **args);
 
 #endif

--- a/includes/minishell_sikeda.h
+++ b/includes/minishell_sikeda.h
@@ -10,12 +10,40 @@
 # include "libft.h"
 
 # define PRG_NAME "minishell"
+# define CMD_OPTION_ERR "invalid option"
+# define CMD_CD_HELP "cd"
+# define CMD_PWD_HELP "pwd"
 
+# define FREE(p) ((p) ? free(p) : (p), (p) = NULL)
+
+enum	e_cmd_signal
+{
+	KEEP_RUNNING,
+	STOP
+};
+
+char	*g_pwd;
+
+/*
+** env_utils.c
+*/
+char	*get_env_by_key(char *key, char **environ);
 /*
 ** command_utils.c
 */
 int		ft_strcmp(const char *s1, const char *s2);
+char	*get_cmd_option(char *option, const char *arg);
 void	ft_put_cmderror(char *cmd_name, char *msg);
 void	ft_put_cmderror_with_arg(char *cmd_name, char *msg, char *arg);
+void	ft_put_cmderror_with_help(char *cmd_name, char *help);
+/*
+** cd.c
+*/
+int		ft_cd(char **args);
+/*
+** pwd.c
+*/
+int		init_pwd(char **environ);
+int		ft_pwd(char **args);
 
 #endif

--- a/pwdtest.sh
+++ b/pwdtest.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+cd libft
+make
+cd ..
+gcc -Wall -Wextra -Werror -I./includes -I./libft srcs/cd.c srcs/pwd.c srcs/command_utils.c srcs/env_utils.c -Llibft -lft -D PWDTEST -o pwd.out
+
+YELLOW=$(printf '\033[33m')
+RESET=$(printf '\033[0m')
+
+WORKDIR=`pwd`
+
+printf "${YELLOW}%s${RESET}\n" "./pwd.out"
+./pwd.out
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] pwd"
+export PWD=hello
+./pwd.out pwd
+printf "${YELLOW}%s${RESET}\n" "[bash] pwd"
+export PWD=hello
+pwd
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] pwd ~"
+./pwd.out pwd ~
+printf "${YELLOW}%s${RESET}\n" "[bash] pwd ~"
+pwd ~
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] pwd \"~\""
+./pwd.out pwd "~"
+printf "${YELLOW}%s${RESET}\n" "[bash] pwd \"~\""
+pwd "~"
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] pwd \"\""
+./pwd.out pwd "~"
+printf "${YELLOW}%s${RESET}\n" "[bash] pwd \"\""
+pwd ""
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] pwd ''"
+./pwd.out pwd ''
+printf "${YELLOW}%s${RESET}\n" "[bash] pwd ''"
+pwd ''
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] pwd \$HOME"
+./pwd.out pwd $HOME
+printf "${YELLOW}%s${RESET}\n" "[bash] pwd \$HOME"
+pwd $HOME
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] pwd hoge"
+./pwd.out pwd hoge
+printf "${YELLOW}%s${RESET}\n" "[bash] pwd hoge"
+pwd hoge
+echo
+
+printf "${YELLOW}%s${RESET}\n" "mkdir pwdtest"
+mkdir pwdtest
+printf "${YELLOW}%s${RESET}\n" "[mini] pwd; cd pwdtest; pwd"
+./pwd.out cd pwdtest
+printf "${YELLOW}%s${RESET}\n" "[bash] pwd; cd pwdtest; pwd"
+pwd
+cd pwdtest
+pwd
+echo
+cd $WORKDIR
+
+printf "${YELLOW}%s${RESET}\n" "[mini] pwd hoge world"
+./pwd.out pwd hoge world
+printf "${YELLOW}%s${RESET}\n" "[bash] pwd hoge world"
+pwd hoge world
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] pwd -"
+./pwd.out pwd -
+printf "${YELLOW}%s${RESET}\n" "[bash] pwd -"
+pwd -
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] pwd -a"
+./pwd.out pwd -a
+printf "${YELLOW}%s${RESET}\n" "[bash] pwd -a"
+pwd -a
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] pwd --version"
+./pwd.out pwd --version
+printf "${YELLOW}%s${RESET}\n" "[bash] pwd --version"
+pwd --version
+echo
+
+rm -rf pwdtest

--- a/srcs/cd.c
+++ b/srcs/cd.c
@@ -1,6 +1,6 @@
 #include "minishell_sikeda.h"
 
-// debug
+#ifdef CDTEST
 int
 	lsh_launch(char **args)
 {
@@ -23,19 +23,24 @@ int
 	}
 	return (1);
 }
+#endif
 
 int
 	ft_cd(char **args)
 {
+#ifdef CDTEST
 	char	*debug_ls[] = {"pwd", NULL};
 
 	lsh_launch(debug_ls);
+#endif
 	if (args[1] == NULL)
 		ft_put_cmderror("cd", strerror(EINVAL));
 	else if (chdir(args[1]) != 0)
 		ft_put_cmderror_with_arg("cd", strerror(errno), args[1]);
+#ifdef CDTEST
 	lsh_launch(debug_ls);
-	return (1);
+#endif
+	return (KEEP_RUNNING);
 }
 
 #ifdef CDTEST
@@ -60,9 +65,9 @@ int
 	ret = 0;
 	if (!ft_strcmp(args[1], "cd"))
 		ret = ft_cd(++args);
-	if (!ret)
+	if (ret == STOP)
 	{
-		// TODO: exitが呼ばれたときに0が返されてloopを終了してmainが終了するイメージ
+		// TODO: exitが呼ばれたときにSTOPが返されてloopを終了してmainが終了するイメージ
 	}
 	return (EXIT_SUCCESS);
 }

--- a/srcs/command_utils.c
+++ b/srcs/command_utils.c
@@ -13,6 +13,21 @@ int
 	return (0);
 }
 
+char
+	*get_cmd_option(char *option, const char *arg)
+{
+	if (!option || !arg)
+		return (NULL);
+	if (arg[0] == '-' && arg[1] != '\0')
+	{
+		option[0] = '-';
+		option[1] = arg[1];
+		option[2] = '\0';
+		return (option);
+	}
+	return (NULL);
+}
+
 void
 	ft_put_cmderror(char *cmd_name, char *msg)
 {
@@ -39,4 +54,15 @@ void
 	ft_putstr_fd(arg, fd);
 	ft_putstr_fd(": ", fd);
 	ft_putendl_fd(msg, fd);
+}
+
+void
+	ft_put_cmderror_with_help(char *cmd_name, char *help)
+{
+	int	fd;
+
+	fd = STDERR_FILENO;
+	ft_putstr_fd(cmd_name, fd);
+	ft_putstr_fd(": usage: ", fd);
+	ft_putendl_fd(help, fd);
 }

--- a/srcs/command_utils.c
+++ b/srcs/command_utils.c
@@ -14,7 +14,7 @@ int
 }
 
 char
-	*get_cmd_option(char *option, const char *arg)
+	*ft_get_cmd_option(char *option, const char *arg)
 {
 	if (!option || !arg)
 		return (NULL);

--- a/srcs/env_utils.c
+++ b/srcs/env_utils.c
@@ -1,0 +1,18 @@
+#include "minishell_sikeda.h"
+
+char
+	*get_env_by_key(char *key, char **environ)
+{
+	size_t	len;
+
+	if (!environ)
+		return (NULL);
+	len = ft_strlen(key);
+	while (*environ)
+	{
+		if (!ft_strncmp(key, *environ, len) && (*environ)[len] == '=')
+			return (ft_strdup(*environ + len + 1));
+		environ++;
+	}
+	return (NULL);
+}

--- a/srcs/env_utils.c
+++ b/srcs/env_utils.c
@@ -1,18 +1,21 @@
 #include "minishell_sikeda.h"
 
 char
-	*get_env_by_key(char *key, char **environ)
+	*ft_getenv(const char *name)
 {
-	size_t	len;
+	extern char	**environ;
+	char		**envptr;
+	size_t		len;
 
-	if (!environ)
+	if (!environ || !*name)
 		return (NULL);
-	len = ft_strlen(key);
-	while (*environ)
+	len = ft_strlen(name);
+	envptr = environ;
+	while (*envptr)
 	{
-		if (!ft_strncmp(key, *environ, len) && (*environ)[len] == '=')
-			return (ft_strdup(*environ + len + 1));
-		environ++;
+		if (!ft_strncmp(name, *envptr, len) && (*envptr)[len] == '=')
+			return (ft_strdup(*envptr + len + 1));
+		envptr++;
 	}
 	return (NULL);
 }

--- a/srcs/pwd.c
+++ b/srcs/pwd.c
@@ -4,11 +4,11 @@ extern char
 	*g_pwd;
 
 int
-	init_pwd(char **environ)
+	ft_init_pwd()
 {
 	int	fd;
 
-	if ((g_pwd = get_env_by_key("PWD", environ)))
+	if ((g_pwd = ft_getenv("PWD")))
 		if (0 <= (fd = open(g_pwd, O_RDONLY)) && close(fd))
 			return (KEEP_RUNNING);
 	if ((g_pwd = getcwd(NULL, 0)))
@@ -27,7 +27,7 @@ int
 	char	option[3];
 
 	dir = NULL;
-	if (get_cmd_option(option, args[1]))
+	if (ft_get_cmd_option(option, args[1]))
 	{
 		ft_put_cmderror_with_arg("pwd", CMD_OPTION_ERR, option);
 		ft_put_cmderror_with_help("pwd", CMD_PWD_HELP);
@@ -41,7 +41,6 @@ int
 int
 	main(int ac, char **av)
 {
-	extern char	**environ;
 	char		**args;
 	int			ret;
 	int			i;
@@ -51,7 +50,7 @@ int
 		ft_put_cmderror("main", strerror(EINVAL));
 		return (EXIT_FAILURE);
 	}
-	if (init_pwd(environ) == STOP)
+	if (ft_init_pwd() == STOP)
 		return (EXIT_FAILURE);
 	if (!(args = (char **)malloc(sizeof(char*) * (ac + 1))))
 		return (EXIT_FAILURE);

--- a/srcs/pwd.c
+++ b/srcs/pwd.c
@@ -1,0 +1,80 @@
+#include "minishell_sikeda.h"
+
+extern char
+	*g_pwd;
+
+int
+	init_pwd(char **environ)
+{
+	int	fd;
+
+	if ((g_pwd = get_env_by_key("PWD", environ)))
+		if (0 <= (fd = open(g_pwd, O_RDONLY)) && close(fd))
+			return (KEEP_RUNNING);
+	if ((g_pwd = getcwd(NULL, 0)))
+	{
+		// TODO: $PWDの値を更新
+		return (KEEP_RUNNING);
+	}
+	ft_putendl_fd(strerror(EINVAL), STDERR_FILENO);
+	return (STOP);
+}
+
+int
+	ft_pwd(char **args)
+{
+	char	*dir;
+	char	option[3];
+
+	dir = NULL;
+	if (get_cmd_option(option, args[1]))
+	{
+		ft_put_cmderror_with_arg("pwd", CMD_OPTION_ERR, option);
+		ft_put_cmderror_with_help("pwd", CMD_PWD_HELP);
+	}
+	else
+		ft_putendl_fd(g_pwd, STDOUT_FILENO);
+	return (KEEP_RUNNING);
+}
+
+#ifdef PWDTEST
+int
+	main(int ac, char **av)
+{
+	extern char	**environ;
+	char		**args;
+	int			ret;
+	int			i;
+
+	if (ac < 2)
+	{
+		ft_put_cmderror("main", strerror(EINVAL));
+		return (EXIT_FAILURE);
+	}
+	if (init_pwd(environ) == STOP)
+		return (EXIT_FAILURE);
+	if (!(args = (char **)malloc(sizeof(char*) * (ac + 1))))
+		return (EXIT_FAILURE);
+	i = -1;
+	while (++i < ac)
+		args[i] = av[i];
+	args[i] = NULL;
+	ret = 0;
+	if (!ft_strcmp(args[1], "cd"))
+	{
+		++args;
+		ret = ft_pwd(args);
+		ret = ft_cd(args);
+		ret = ft_pwd(args);
+	}
+	else if (!ft_strcmp(args[1], "pwd"))
+		ret = ft_pwd(++args);
+	if (ret == STOP)
+	{
+		// TODO: exitが呼ばれたときにSTOPが返されてloopを終了してmainが終了するイメージ
+	}
+	g_pwd ? FREE(g_pwd) : g_pwd;
+	// system("leaks pwd.out");
+	return (EXIT_SUCCESS);
+}
+#endif


### PR DESCRIPTION
# 概要
pwd関数の追加

# 受入条件
内容確認、動作確認

# コメント
- ./pwdtest.sh でコンパイルといくつかのテストを実行します
  -  18行目：ecport PWD=helloで$PWDの値をパスではなく関係ない文字列にしてそれでもpwdコマンドが動くか見ています
  - 64行目：cdした後にpwdをするのでcd関数の方も少し書き換えています
  - 64行目：pwdで見る値はcdするたびに書き換える想定です、cd関数の方にはその仕様がまだ実装されていないのでbashとの差異が出ます（pwdしても前のパスから変わらない）
- srcs/pwd.c
  - 7行目：ft_init_pwd()：minishell起動時に呼ばれる想定です、起動時のパスを取得します
  - 16行目：PWDの値の書き換えは今後実装予定です（環境変数の値の変更）

close #34 