### PR TITLE
fix #45 memory leaks & close condition

### DIFF
--- a/srcs/pwd.c
+++ b/srcs/pwd.c
@@ -9,26 +9,27 @@ int
 	int	fd;
 
 	if ((g_pwd = ft_getenv("PWD")))
-		if (0 <= (fd = open(g_pwd, O_RDONLY)) && close(fd))
+		if (0 <= (fd = open(g_pwd, O_RDONLY)) && close(fd) <= 0)
 			return (KEEP_RUNNING);
-	if ((g_pwd = getcwd(NULL, 0)))
+	FREE(g_pwd);
+	if (!(g_pwd = getcwd(NULL, 0)))
 	{
-		// TODO: $PWDの値を更新
-		return (KEEP_RUNNING);
+		// TODO: エラーステータス設定
+		ft_putendl_fd(strerror(errno), STDERR_FILENO);
+		return (STOP);
 	}
-	ft_putendl_fd(strerror(EINVAL), STDERR_FILENO);
-	return (STOP);
+	// TODO: $PWDの値を更新
+	return (KEEP_RUNNING);
 }
 
 int
 	ft_pwd(char **args)
 {
-	char	*dir;
 	char	option[3];
 
-	dir = NULL;
 	if (ft_get_cmd_option(option, args[1]))
 	{
+		// TODO: エラーステータス設定
 		ft_put_cmderror_with_arg("pwd", CMD_OPTION_ERR, option);
 		ft_put_cmderror_with_help("pwd", CMD_PWD_HELP);
 	}
@@ -42,6 +43,7 @@ int
 	main(int ac, char **av)
 {
 	char		**args;
+	char		**args_head;
 	int			ret;
 	int			i;
 
@@ -53,11 +55,15 @@ int
 	if (ft_init_pwd() == STOP)
 		return (EXIT_FAILURE);
 	if (!(args = (char **)malloc(sizeof(char*) * (ac + 1))))
+	{
+		FREE(g_pwd);
 		return (EXIT_FAILURE);
+	}
 	i = -1;
 	while (++i < ac)
 		args[i] = av[i];
 	args[i] = NULL;
+	args_head = args;
 	ret = 0;
 	if (!ft_strcmp(args[1], "cd"))
 	{
@@ -72,7 +78,8 @@ int
 	{
 		// TODO: exitが呼ばれたときにSTOPが返されてloopを終了してmainが終了するイメージ
 	}
-	g_pwd ? FREE(g_pwd) : g_pwd;
+	FREE(args_head);
+	FREE(g_pwd);
 	// system("leaks pwd.out");
 	return (EXIT_SUCCESS);
 }


### PR DESCRIPTION
# 概要
ft_init_pwd関数のバグ修正

# 受入条件
内容確認、動作確認（main内のsystem("leaks pwd.out");のコメントを外してからpwdtest.shを実行するとリークチェックも行われます）

# コメント
- 12行目：closeを１行で行うためにif内に書いていましたが、openが成功して0を返したときに抜けて14行目に進んでしまうバグがあり、修正しました
- 14行目：15行目でg_pwdの値を書き換える前にfreeしていなかったのでfreeを追加しました
- main関数でもfreeをしっかりするように修正しています

close #45 