### PR TITLE
add #35 exit function

### DIFF
--- a/exittest.sh
+++ b/exittest.sh
@@ -1,0 +1,256 @@
+#!/bin/bash
+
+cd libft
+make
+cd ..
+gcc -g -Wall -Wextra -Werror -I./includes -I./libft srcs/cd.c srcs/pwd.c srcs/exit.c srcs/command_utils.c srcs/env_utils.c -Llibft -lft -D EXITTEST -o exit.out
+
+YELLOW=$(printf '\033[33m')
+RESET=$(printf '\033[0m')
+
+WORKDIR=`pwd`
+
+printf "${YELLOW}%s${RESET}\n" "./exit.out"
+./exit.out
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit"
+./exit.out exit
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit"
+echo "exit" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit ~"
+./exit.out exit ~
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit ~"
+echo "exit ~" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit \"~\""
+./exit.out exit "~"
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit \"~\""
+echo "exit \"~\"" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit \"\""
+./exit.out exit ""
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit \"\""
+echo "exit \"\"" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit ''"
+./exit.out exit ''
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit ''"
+echo "exit ''" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit \$HOME"
+./exit.out exit $HOME
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit \$HOME"
+echo "exit $HOME" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit hoge"
+./exit.out exit hoge
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit hoge"
+echo "exit hoge" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit hoge world"
+./exit.out exit hoge world
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit hoge world"
+echo "exit hoge world" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit -"
+./exit.out exit -
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit -"
+echo "exit -" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit -a"
+./exit.out exit -a
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit -a"
+echo "exit -a" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit --version"
+./exit.out exit --version
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit --version"
+echo "exit --version" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit 1"
+./exit.out exit 1
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit 1"
+echo "exit 1" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit 3"
+./exit.out exit 3
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit 3"
+echo "exit 3" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit 0"
+./exit.out exit 0
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit 0"
+echo "exit 0" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit +100"
+./exit.out exit +100
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit +100"
+echo "exit +100" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit -1"
+./exit.out exit -1
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit -1"
+echo "exit -1" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit --1"
+./exit.out exit --1
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit --1"
+echo "exit --1" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit --"
+./exit.out exit --
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit --"
+echo "exit --" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit -- \"   5   \""
+./exit.out exit -- "   5   "
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit -- \"   5   \""
+echo "exit -- \"   5   \"" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit a"
+./exit.out exit a
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit a"
+echo "exit a" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit 255"
+./exit.out exit 255
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit 255"
+echo "exit 255" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit 300"
+./exit.out exit 300
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit 300"
+echo "exit 300" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit 2147483647"
+./exit.out exit 2147483647
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit 2147483647"
+echo "exit 2147483647" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit 2147483650"
+./exit.out exit 2147483650
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit 2147483650"
+echo "exit 2147483650" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit 21A"
+./exit.out exit 21A
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit 21A"
+echo "exit 21A" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit 1 2 3"
+./exit.out exit 1 2 3
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit 1 2 3"
+echo "exit 1 2 3" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit 10 a b"
+./exit.out exit 10 a b
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit 10 a B"
+echo "exit 10 a b" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit a 20"
+./exit.out exit a 20
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit a 20"
+echo "exit a 20" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit \"   5   \""
+./exit.out exit "   5   "
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit \"   5   \""
+echo "exit \"   5   \"" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit \"   5 6  \""
+./exit.out exit "   5 6   "
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit \"   5 6  \""
+echo "exit \"   5 6   \"" | bash
+echo $?
+echo

--- a/includes/minishell_sikeda.h
+++ b/includes/minishell_sikeda.h
@@ -10,9 +10,14 @@
 # include "libft.h"
 
 # define PRG_NAME "minishell"
+# define STATUS_SUCCESS 0
+# define STATUS_GENERAL_ERR 1
+# define STATUS_OUT_OF_RANGE_ERR 255
 # define CMD_OPTION_ERR "invalid option"
 # define CMD_CD_HELP "cd"
 # define CMD_PWD_HELP "pwd"
+
+# define SPACE_CHARS " \t\n\v\f\r"
 
 # define FREE(p) ((p) ? free(p) : (p), (p) = NULL)
 
@@ -22,6 +27,7 @@ enum	e_cmd_signal
 	STOP
 };
 
+uint8_t	g_status;
 char	*g_pwd;
 
 /*
@@ -32,6 +38,8 @@ char	*ft_getenv(const char *name);
 ** command_utils.c
 */
 int		ft_strcmp(const char *s1, const char *s2);
+int		ft_isspace(char c);
+int		ft_isnumeric(char *s);
 char	*ft_get_cmd_option(char *option, const char *arg);
 void	ft_put_cmderror(char *cmd_name, char *msg);
 void	ft_put_cmderror_with_arg(char *cmd_name, char *msg, char *arg);
@@ -45,5 +53,9 @@ int		ft_cd(char **args);
 */
 int		ft_init_pwd();
 int		ft_pwd(char **args);
+/*
+** exit.c
+*/
+int		ft_exit(char **args);
 
 #endif

--- a/srcs/command_utils.c
+++ b/srcs/command_utils.c
@@ -13,6 +13,29 @@ int
 	return (0);
 }
 
+int
+	ft_isspace(char c)
+{
+	return (c == ' ' || (9 <= c && c <= 13));
+}
+
+int
+	ft_isnumeric(char *s)
+{
+	if (!s || *s == '\0')
+		return (0);
+	if (*s == '+' || *s == '-')
+		s++;
+	if (!ft_isdigit(*s))
+		return (0);
+	while (*s)
+	{
+		if (!ft_isdigit(*s++))
+			return (0);
+	}
+	return (1);
+}
+
 char
 	*ft_get_cmd_option(char *option, const char *arg)
 {

--- a/srcs/exit.c
+++ b/srcs/exit.c
@@ -1,0 +1,100 @@
+#include "minishell_sikeda.h"
+
+static int
+	exit_with_args(char **args)
+{
+	char	*trimmed_arg;
+
+	if (!(trimmed_arg = ft_strtrim(args[1], SPACE_CHARS)))
+	{
+		ft_put_cmderror("exit", strerror(errno));
+		return (STOP);
+	}
+	if (ft_isnumeric(trimmed_arg))
+	{
+		g_status = ft_atoi(trimmed_arg);
+		if (args[2])
+		{
+			ft_put_cmderror("exit", "too many arguments");
+			g_status = STATUS_GENERAL_ERR;
+			FREE(trimmed_arg);
+			return (KEEP_RUNNING);
+		}
+	}
+	else
+	{
+		ft_put_cmderror_with_arg("exit", "numeric argument required", args[1]);
+		g_status = STATUS_OUT_OF_RANGE_ERR;
+	}
+	FREE(trimmed_arg);
+	return (STOP);
+}
+
+int
+	ft_exit(char **args)
+{
+	g_status = STATUS_SUCCESS;
+	ft_putendl_fd("exit", STDERR_FILENO);
+	if (args[1])
+	{
+		if (!ft_strcmp(args[1], "--"))
+		{
+			if (!args[2])
+				return (STOP);
+			args++;
+		}
+		g_status = STATUS_GENERAL_ERR;
+		return (exit_with_args(args));
+	}
+	return (STOP);
+}
+
+#ifdef EXITTEST
+int
+	main(int ac, char **av)
+{
+	char		**args;
+	char		**args_head;
+	int			ret;
+	int			i;
+
+	if (ac < 2)
+	{
+		ft_put_cmderror("main", strerror(EINVAL));
+		return (EXIT_FAILURE);
+	}
+	if (ft_init_pwd() == STOP)
+		return (EXIT_FAILURE);
+	if (!(args = (char **)malloc(sizeof(char*) * (ac + 1))))
+	{
+		FREE(g_pwd);
+		return (EXIT_FAILURE);
+	}
+	i = -1;
+	while (++i < ac)
+		args[i] = av[i];
+	args[i] = NULL;
+	args_head = args;
+	ret = 0;
+	if (!ft_strcmp(args[1], "cd"))
+	{
+		++args;
+		ret = ft_pwd(args);
+		ret = ft_cd(args);
+		ret = ft_pwd(args);
+	}
+	else if (!ft_strcmp(args[1], "pwd"))
+		ret = ft_pwd(++args);
+	else
+	if (!ft_strcmp(args[1], "exit"))
+		ret = ft_exit(++args);
+	if (ret == STOP)
+	{
+		// TODO: exitが呼ばれたときにSTOPが返されてloopを終了してmainが終了するイメージ
+	}
+	FREE(args_head);
+	FREE(g_pwd);
+	// system("leaks exit.out");
+	return (g_status);
+}
+#endif


### PR DESCRIPTION
# 概要
exit関数の追加

# 受入条件
内容確認、動作確認

# コメント
- ./exittest.shにより、exit.outが作成されるので 「./exit.out exit 42」のように実行していただくと試せます
- leakチェックをすると先にプルリク出しているft_init_pwd()のleakが検出されると思うのでご了承ください。。
- exittest.shを実行すると、minishellの方はexitと標準エラーに出力し、bashの方は出ていません。bashの方に"exit"と出ないのはシェルスクリプトで「echo "exit" | bash」のように実行だからかもしれないです（単に「exit」と書くとテストがそこで終了してしまう）。通常はbashを起動してexitコマンドを使用するとまず"exit"と標準エラーに出力されます。
- exittest.shを実行すると、"exit"と出た後に数字が出ますが、これはシェルの終了ステータスです。

close #35 