### PR TITLE
add #37 env function

### DIFF
--- a/envtest.sh
+++ b/envtest.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+
+cd libft
+make bonus
+cd ..
+gcc -g -Wall -Wextra -Werror -I./includes -I./libft srcs/cd.c srcs/pwd.c srcs/exit.c srcs/env.c srcs/command_utils.c srcs/env_utils.c -Llibft -lft -D ENVTEST -o env.out
+
+YELLOW=$(printf '\033[33m')
+RESET=$(printf '\033[0m')
+
+printf "${YELLOW}%s${RESET}\n" "[mini] env"
+./env.out env > mini_env
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] env"
+echo "env > bash_env" | bash
+echo $?
+# _=で始まる変数は最後に実行したコマンドの引数で、bashとminishellの呼び出し方が異なるので、この値も異なるため除外する
+sed -e '/^_=/d' mini_env > mini_env_sed
+sed -e '/^_=/d' bash_env > bash_env_sed
+# 順番を同じにすることができない（?）ので文字数で比較
+cat mini_env_sed | wc > mini_env_wc
+cat bash_env_sed | wc > bash_env_wc
+echo "===diff check start==="
+diff mini_env_wc bash_env_wc
+echo "===diff check end==="
+rm mini_env mini_env_sed mini_env_wc bash_env bash_env_sed bash_env_wc
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] env --"
+./env.out env -- > mini_env
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] env --"
+echo "env > bash_env --" | bash
+echo $?
+# _=で始まる変数は最後に実行したコマンドの引数で、bashとminishellの呼び出し方が異なるので、この値も異なるため除外する
+sed -e '/^_=/d' mini_env > mini_env_sed
+sed -e '/^_=/d' bash_env > bash_env_sed
+# 順番を同じにすることができない（?）ので文字数で比較
+cat mini_env_sed | wc > mini_env_wc
+cat bash_env_sed | wc > bash_env_wc
+echo "===diff check start==="
+diff mini_env_wc bash_env_wc
+echo "===diff check end==="
+rm mini_env mini_env_sed mini_env_wc bash_env bash_env_sed bash_env_wc
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] env -a"
+./env.out env -a
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] env -a"
+echo "env -a" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] env - - -a"
+./env.out env - - -a
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] env - - -a"
+echo "env - - -a" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] env --envtestdir"
+./env.out env --envtestdir
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] env --envtestdir"
+echo "env --envtestdir" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] env envtestdir"
+./env.out env envtestdir
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] env envtestdir"
+echo "env envtestdir" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] env -"
+./env.out env -
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] env -"
+echo "env -" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] env - -"
+./env.out env - -
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] env - -"
+echo "env - -" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] env - - - ----"
+./env.out env - - - ----
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] env - - - ----"
+echo "env - - - ----" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] env - - - --"
+./env.out env - - - --
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] env - - - --"
+echo "env - - - --" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] env - - - -- -"
+./env.out env - - - -- -
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] env - - - -- -"
+echo "env - - - -- -" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] env - - - -- -a"
+./env.out env - - - -- -a
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] env - - - -- -a"
+echo "env - - - -- -a" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] env - - - --- -a"
+./env.out env - - - --- -a
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] env - - - --- -a"
+echo "env - - - --- -a" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] env -- -"
+./env.out env -- -
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] env -- -"
+echo "env -- -" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] env -- --"
+./env.out env -- --
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] env -- --"
+echo "env -- --" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] env --- -"
+./env.out env --- -
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] env --- -"
+echo "env --- -" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] env - envtestdir"
+./env.out env - envtestdir
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] env - envtestdir"
+echo "env - envtestdir" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] env -- envtestdir"
+./env.out env -- envtestdir
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] env -- envtestdir"
+echo "env -- envtestdir" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] env --- envtestdir"
+./env.out env --- envtestdir
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] env --- envtestdir"
+echo "env --- envtestdir" | bash
+echo $?
+echo

--- a/includes/minishell_sikeda.h
+++ b/includes/minishell_sikeda.h
@@ -16,6 +16,7 @@
 # define CMD_OPTION_ERR "invalid option"
 # define CMD_CD_HELP "cd [dir]"
 # define CMD_PWD_HELP "pwd"
+# define CMD_ENV_HELP "env"
 
 # define SPACE_CHARS " \t\n\v\f\r"
 
@@ -35,6 +36,7 @@ enum	e_cmd_signal
 
 uint8_t	g_status;
 char	*g_pwd;
+t_list	*g_env;
 
 /*
 ** env_utils.c
@@ -57,8 +59,13 @@ int		ft_cd(char **args);
 /*
 ** pwd.c
 */
-int		ft_init_pwd();
+int		ft_init_pwd(void);
 int		ft_pwd(char **args);
+/*
+** env.c
+*/
+int		ft_init_env(void);
+int		ft_env(char **args);
 /*
 ** exit.c
 */

--- a/pwdtest.sh
+++ b/pwdtest.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 cd libft
-make
+make bonus
 cd ..
-gcc -Wall -Wextra -Werror -I./includes -I./libft srcs/cd.c srcs/pwd.c srcs/command_utils.c srcs/env_utils.c -Llibft -lft -D PWDTEST -o pwd.out
+gcc -Wall -Wextra -Werror -I./includes -I./libft srcs/cd.c srcs/pwd.c srcs/exit.c srcs/env.c srcs/command_utils.c srcs/env_utils.c -Llibft -lft -D PWDTEST -o pwd.out
 
 YELLOW=$(printf '\033[33m')
 RESET=$(printf '\033[0m')

--- a/srcs/env.c
+++ b/srcs/env.c
@@ -1,0 +1,181 @@
+#include "../includes/minishell_sikeda.h"
+
+int
+	ft_init_env(void)
+{
+	extern char	**environ;
+	t_list		*new;
+	char		*cpy;
+	int			i;
+
+	i = 0;
+	while (environ[i])
+	{
+		if (!ft_strncmp(environ[i], "OLDPWD=", ft_strlen("OLDPWD=")))
+		{
+			i++;
+			continue ;
+		}
+		if (!(cpy = ft_strdup(environ[i])) || !(new = ft_lstnew(cpy)))
+		{
+			cpy ? FREE(cpy) : cpy;
+			ft_lstclear(&g_env, free);
+			return (STOP);
+		}
+		if (i == 0)
+			g_env = new;
+		else
+			ft_lstadd_back(&g_env, new);
+		i++;
+	}
+	return (KEEP_RUNNING);
+}
+
+static void
+	put_enverror_with_option(char *option)
+{
+	int	fd;
+
+	fd = STDERR_FILENO;
+	ft_putstr_fd("env: illegal option -- ", fd);
+	write(fd, option, 1);
+	write(fd, "\n", 1);
+	ft_putstr_fd("usage: ", fd);
+	ft_putendl_fd(CMD_ENV_HELP, fd);
+}
+
+static char
+	*check_args(char **args, t_bool *has_path)
+{
+	char	*option;
+	int		i;
+
+	option = NULL;
+	while (args[1])
+	{
+		if (!ft_strcmp(args[1], "--") && args[2])
+		{
+			*has_path = TRUE;
+			args++;
+		}
+		else
+		{
+			i = 0;
+			while (args[1][i] == '-')
+				i++;
+			if (args[1][i] == '\0')
+				args++;
+			else if (0 < i)
+				option = &args[1][i];
+			else
+				*has_path = TRUE;
+		}
+		if (*has_path == TRUE || option)
+			break ;
+	}
+	return (option);
+}
+
+static void
+	env_with_args(char **args)
+{
+	char	*option;
+	t_bool	has_path;
+
+	has_path = FALSE;
+	option = check_args(args, &has_path);
+	if (has_path == FALSE && option)
+	{
+		g_status = STATUS_GENERAL_ERR;
+		put_enverror_with_option(option);
+	}
+	else if (has_path == TRUE || option)
+	{
+		g_status = STATUS_GENERAL_ERR;
+		ft_put_cmderror_with_help("env", CMD_ENV_HELP);
+	}
+}
+
+static t_bool
+	is_only_double_hyphen(char **args)
+{
+	return ((!ft_strcmp(args[1], "--") && !args[2]));
+}
+
+int
+	ft_env(char **args)
+{
+	t_list	*envptr;
+
+	g_status = STATUS_SUCCESS;
+	if (args[1] && !is_only_double_hyphen(args))
+		env_with_args(args);
+	else
+	{
+		envptr = g_env;
+		while (envptr)
+		{
+			ft_putendl_fd(envptr->content, STDOUT_FILENO);
+			envptr = envptr->next;
+		}
+	}
+	return (KEEP_RUNNING);
+}
+
+#ifdef ENVTEST
+int
+	main(int ac, char **av)
+{
+	char	**args;
+	char	**args_head;
+	int		ret;
+	int		i;
+
+	if (ac < 2)
+	{
+		ft_put_cmderror("main", strerror(EINVAL));
+		return (EXIT_FAILURE);
+	}
+	if (ft_init_env() == STOP)
+		return (EXIT_FAILURE);
+	if (ft_init_pwd() == STOP)
+	{
+		ft_lstclear(&g_env, free);
+		return (EXIT_FAILURE);
+	}
+	if (!(args = (char **)malloc(sizeof(char*) * (ac + 1))))
+	{
+		FREE(g_pwd);
+		ft_lstclear(&g_env, free);
+		return (EXIT_FAILURE);
+	}
+	i = -1;
+	while (++i < ac)
+		args[i] = av[i];
+	args[i] = NULL;
+	args_head = args;
+	ret = 0;
+	if (!ft_strcmp(args[1], "cd"))
+	{
+		++args;
+		ret = ft_pwd(args);
+		ret = ft_cd(args);
+		ret = ft_pwd(args);
+	}
+	else if (!ft_strcmp(args[1], "pwd"))
+		ret = ft_pwd(++args);
+	else if (!ft_strcmp(args[1], "env"))
+		ret = ft_env(++args);
+	else if (!ft_strcmp(args[1], "exit"))
+		ret = ft_exit(++args);
+	if (ret == STOP)
+	{
+		// TODO: exitが呼ばれたときにSTOPが返されてloopを終了してmainが終了するイメージ
+	}
+	FREE(args_head);
+	FREE(g_pwd);
+	ft_lstclear(&g_env, free);
+	// system("leaks env.out");
+	return (g_status);
+}
+#endif

--- a/srcs/env_utils.c
+++ b/srcs/env_utils.c
@@ -3,19 +3,20 @@
 char
 	*ft_getenv(const char *name)
 {
-	extern char	**environ;
-	char		**envptr;
-	size_t		len;
+	t_list	*envptr;
+	size_t	len;
+	char	*current;
 
-	if (!environ || !*name)
+	if (!g_env || !*name)
 		return (NULL);
 	len = ft_strlen(name);
-	envptr = environ;
-	while (*envptr)
+	envptr = g_env;
+	while (envptr)
 	{
-		if (!ft_strncmp(name, *envptr, len) && (*envptr)[len] == '=')
-			return (ft_strdup(*envptr + len + 1));
-		envptr++;
+		current = envptr->content;
+		if (!ft_strncmp(name, current, len) && current[len] == '=')
+			return (ft_strdup(current + len + 1));
+		envptr = envptr->next;
 	}
 	return (NULL);
 }

--- a/srcs/pwd.c
+++ b/srcs/pwd.c
@@ -4,7 +4,7 @@ extern char
 	*g_pwd;
 
 int
-	ft_init_pwd()
+	ft_init_pwd(void)
 {
 	int	fd;
 
@@ -52,11 +52,17 @@ int
 		ft_put_cmderror("main", strerror(EINVAL));
 		return (EXIT_FAILURE);
 	}
-	if (ft_init_pwd() == STOP)
+	if (ft_init_env() == STOP)
 		return (EXIT_FAILURE);
+	if (ft_init_pwd() == STOP)
+	{
+		ft_lstclear(&g_env, free);
+		return (EXIT_FAILURE);
+	}
 	if (!(args = (char **)malloc(sizeof(char*) * (ac + 1))))
 	{
 		FREE(g_pwd);
+		ft_lstclear(&g_env, free);
 		return (EXIT_FAILURE);
 	}
 	i = -1;
@@ -74,12 +80,17 @@ int
 	}
 	else if (!ft_strcmp(args[1], "pwd"))
 		ret = ft_pwd(++args);
+	else if (!ft_strcmp(args[1], "env"))
+		ret = ft_env(++args);
+	else if (!ft_strcmp(args[1], "exit"))
+		ret = ft_exit(++args);
 	if (ret == STOP)
 	{
 		// TODO: exitが呼ばれたときにSTOPが返されてloopを終了してmainが終了するイメージ
 	}
 	FREE(args_head);
 	FREE(g_pwd);
+	ft_lstclear(&g_env, free);
 	// system("leaks pwd.out");
 	return (EXIT_SUCCESS);
 }


### PR DESCRIPTION
# 概要
env関数作成 issue #37

# 受入条件
内容確認、動作確認

# コメント
- ./envtest.shにより、env.outが作成されるので 「./env.out env」のように実行して頂くと試せます
- ./envtest.sh
  - 11行目~ & 29行目~：envコマンド実行後の環境変数の並び順に規則性が見出せません。レビューでレビューイーの方に聞いたら再現が難しいとのことでした。このテストでは「_」という環境変数以外の文字数でminishellとbashをdiffで比較しています。
  - 71行目等：bashではenvの機能によりディレクトリかファイルを探しています。minishellではusageを出しています。終了ステータスもただの1を返すようにしています。
- 環境変数の持ち方を変え、既存のft_getenv()も変えました。この関数を呼び出しているpwdのテストもできるように、pwd.cのmainとpwdtest.shも変えてコミットに含めています。

close #37 