### PR TITLE
add #38 export function

### DIFF
--- a/exporttest.sh
+++ b/exporttest.sh
@@ -1,0 +1,326 @@
+#!/bin/bash
+
+cd libft
+make bonus
+cd ..
+gcc -g -Wall -Wextra -Werror -I./includes -I./libft srcs/cd.c srcs/pwd.c srcs/exit.c srcs/env.c srcs/unset.c srcs/export.c srcs/command_utils.c srcs/env_utils.c -Llibft -lft -D EXPORTTEST -o export.out
+
+YELLOW=$(printf '\033[33m')
+CYAN=$(printf '\033[36m')
+RESET=$(printf '\033[0m')
+
+printf "${YELLOW}%s${RESET}\n" "[mini] export"
+./export.out export > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export"
+echo "export > bash_export" | bash
+echo $?
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] export --"
+./export.out export -- > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export --"
+echo "export -- > bash_export" | bash
+echo $?
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+
+printf "${CYAN}%s${RESET}\n" "export EXPORTTEST=0123"
+export EXPORTTEST=0123
+printf "${YELLOW}%s${RESET}\n" "[mini] export"
+./export.out export > mini_export
+echo $?
+printf "${CYAN}%s${RESET}\n" "export EXPORTTEST=0123"
+export EXPORTTEST=0123
+printf "${YELLOW}%s${RESET}\n" "[bash] export"
+echo "export > bash_export" | bash
+echo $?
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+printf "${CYAN}%s${RESET}\n" "unset EXPORTTEST"
+unset EXPORTTEST
+rm mini_export bash_export
+echo
+
+# nameのみの環境変数はシェル起動時に引き継がない
+printf "${CYAN}%s${RESET}\n" "export EXPORTTEST"
+export EXPORTTEST
+printf "${YELLOW}%s${RESET}\n" "[mini] export"
+./export.out export > mini_export
+echo $?
+printf "${CYAN}%s${RESET}\n" "export EXPORTTEST"
+export EXPORTTEST
+printf "${YELLOW}%s${RESET}\n" "[bash] export"
+echo "export > bash_export" | bash
+echo $?
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] export -z"
+./export.out export -z
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export -z"
+echo "export -z" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] export \"\""
+./export.out export ""
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export \"\""
+echo "export \"\"" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] export -"
+./export.out export -
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export -"
+echo "export -" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] export ---"
+./export.out export ---
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export ---"
+echo "export ---" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] export -- -z"
+./export.out export -- -z
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export -- -z"
+echo "export -- -z" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] export EXPORTTEST"
+./export.out export EXPORTTEST > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export EXPORTTEST"
+echo "export EXPORTTEST" | bash
+echo $?
+echo "export EXPORTTEST; export > bash_export" | bash
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] export EXPORTTEST="
+./export.out export EXPORTTEST= > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export EXPORTTEST="
+echo "export EXPORTTEST=" | bash
+echo $?
+echo "export EXPORTTEST= ; export > bash_export" | bash
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] export EXPORTTEST=0123"
+./export.out export EXPORTTEST=0123 > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export EXPORTTEST=0123"
+echo "export EXPORTTEST=0123" | bash
+echo $?
+echo "export EXPORTTEST=0123 ; export > bash_export" | bash
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] export EXPORTTEST=\"B=C\""
+./export.out export EXPORTTEST="B=C" > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export EXPORTTEST=\"B=C\""
+echo "export EXPORTTEST=\"B=C\"" | bash
+echo $?
+echo "export EXPORTTEST=\"B=C\" ; export > bash_export" | bash
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] export \"EXPORTTEST=B\"=C"
+./export.out export "EXPORTTEST=B"=C > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export \"EXPORTTEST=B\"=C"
+echo "export \"EXPORTTEST=B\"=C" | bash
+echo $?
+echo "export \"EXPORTTEST=B\"=C ; export > bash_export" | bash
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] export EXPORTTEST=\"aaa     b\""
+./export.out export EXPORTTEST="aaa     b" > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export EXPORTTEST=\"aaa     b\""
+echo "export EXPORTTEST=\"aaa     b\"" | bash
+echo $?
+echo "export EXPORTTEST=\"aaa     b\" ; export > bash_export" | bash
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] export EXPORTTEST==="
+./export.out export EXPORTTEST=== > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export EXPORTTEST==="
+echo "export EXPORTTEST===" | bash
+echo $?
+echo "export EXPORTTEST=== ; export > bash_export" | bash
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] export EXPORTTEST=\\\"hello\\\""
+./export.out export EXPORTTEST=\"hello\" > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export EXPORTTEST=\\\"hello\\\""
+echo "export EXPORTTEST=\\\"hello\\\"" | bash
+echo $?
+echo "export EXPORTTEST=\\\"hello\\\" ; export > bash_export" | bash
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] export EXPORTTEST=\$hello"
+./export.out export EXPORTTEST=\$hello > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export EXPORTTEST=\$hello"
+echo "export EXPORTTEST=\\\$hello" | bash
+echo $?
+echo "export EXPORTTEST=\\\$hello ; export > bash_export" | bash
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] export EXPORTTEST=\\hello"
+./export.out export EXPORTTEST=\\hello > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export EXPORTTEST=\\hello"
+echo "export EXPORTTEST=\\\\hello" | bash
+echo $?
+echo "export EXPORTTEST=\\\\hello ; export > bash_export" | bash
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] export EXPORTTEST=\`hello"
+./export.out export EXPORTTEST=\`hello > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export EXPORTTEST=\`hello"
+echo "export EXPORTTEST=\\\`hello" | bash
+echo $?
+echo "export EXPORTTEST=\\\`hello ; export > bash_export" | bash
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] export EXPORTTEST= 0123"
+./export.out export EXPORTTEST= 0123 > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export EXPORTTEST= 0123"
+echo "export EXPORTTEST= 0123" | bash
+echo $?
+echo "export EXPORTTEST= 0123 ; export > bash_export" | bash
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+
+# $mark
+printf "${YELLOW}%s${RESET}\n" "[mini] export EXPORTTEST$=0123"
+./export.out export EXPORTTEST$=0123
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export EXPORTTEST$=0123"
+echo "export EXPORTTEST$=0123" | bash
+echo $?
+echo
+
+# 先頭に数字
+printf "${YELLOW}%s${RESET}\n" "[mini] export 0EXPORTTEST=0123"
+./export.out export 0EXPORTTEST=0123
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export 0EXPORTTEST=0123"
+echo "export 0EXPORTTEST=0123" | bash
+echo $?
+echo
+
+# 途中に数字
+printf "${YELLOW}%s${RESET}\n" "[mini] export EXP0RT0TEST=0123"
+./export.out export EXPORT0TEST=0123 > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export 0EXPORT0TEST=0123"
+echo "export EXPORT0TEST=0123" | bash
+echo $?
+echo "export EXPORT0TEST=0123 ; export> bash_export" | bash
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+echo
+
+# 最後に数字
+printf "${YELLOW}%s${RESET}\n" "[mini] export EXP0RTTEST0=0123"
+./export.out export EXPORTTEST0=0123 > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export 0EXPORTTEST0=0123"
+echo "export EXPORTTEST0=0123" | bash
+echo $?
+echo "export EXPORTTEST0=0123 ; export > bash_export" | bash
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+
+# _ (under score)
+printf "${YELLOW}%s${RESET}\n" "[mini] export _A=0123"
+./export.out export _A=0123 > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export _A=0123"
+echo "export _A=0123" | bash
+echo $?
+echo "export _A=0123 ; export > bash_export" | bash
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo

--- a/includes/minishell_sikeda.h
+++ b/includes/minishell_sikeda.h
@@ -21,10 +21,11 @@
 # define CMD_CD_HELP "cd [dir]"
 # define CMD_PWD_HELP "pwd"
 # define CMD_ENV_HELP "env"
+# define CMD_EXPORT_HELP "export [name[=value] ...]"
 # define CMD_UNSET_HELP "unset [name ...]"
 
-# define ENVUTIL_SUCCESS 0
-# define ENVUTIL_ERROR -1
+# define UTIL_SUCCESS 0
+# define UTIL_ERROR -1
 
 # define SPACE_CHARS " \t\n\v\f\r"
 
@@ -36,11 +37,11 @@ typedef enum e_bool
 	TRUE
 }	t_bool;
 
-enum	e_cmd_signal
+typedef enum e_cmd_signal
 {
 	KEEP_RUNNING,
 	STOP
-};
+}	t_cmd_signal;
 
 uint8_t	g_status;
 char	*g_pwd;
@@ -51,6 +52,11 @@ t_list	*g_env;
 */
 char	*ft_getenv(const char *name);
 int		ft_unsetenv(const char *name);
+int		ft_setenv(char *str);
+int		ft_unsetenv(const char *name);
+void	ft_envsort(t_list **lst);
+void	ft_clear_copied_env(t_list **cpy);
+t_list	*ft_copy_env(void);
 /*
 ** command_utils.c
 */
@@ -58,6 +64,7 @@ int		ft_strcmp(const char *s1, const char *s2);
 int		ft_isspace(char c);
 int		ft_isnumeric(char *s);
 char	*ft_get_cmd_option(char *option, const char *arg);
+void	ft_put_error(char *msg);
 void	ft_put_cmderror(char *cmd_name, char *msg);
 void	ft_put_cmderror_with_arg(char *cmd_name, char *msg, char *arg);
 void	ft_put_cmderror_with_quoted_arg(char *cmd_name, char *msg, char *arg);

--- a/srcs/command_utils.c
+++ b/srcs/command_utils.c
@@ -52,6 +52,17 @@ char
 }
 
 void
+	ft_put_error(char *msg)
+{
+	int	fd;
+
+	fd = STDERR_FILENO;
+	ft_putstr_fd(PRG_NAME, fd);
+	ft_putstr_fd(": ", fd);
+	ft_putendl_fd(msg, fd);
+}
+
+void
 	ft_put_cmderror(char *cmd_name, char *msg)
 {
 	int	fd;

--- a/srcs/env_utils.c
+++ b/srcs/env_utils.c
@@ -14,11 +14,53 @@ char
 	while (envptr)
 	{
 		current = envptr->content;
-		if (!ft_strncmp(name, current, len) && current[len] == '=')
+		if (!ft_strncmp(name, current, len)
+		&& (current[len] == '=' || current[len] == '\0'))
 			return (ft_strdup(current + len + 1));
 		envptr = envptr->next;
 	}
 	return (NULL);
+}
+
+static void
+	delone_env(char *str)
+{
+	size_t	len;
+	size_t	i;
+
+	len = ft_strlen(str);
+	i = 0;
+	while (str[i])
+	{
+		if (str[i] == '=')
+		{
+			str[i] = '\0';
+			break ;
+		}
+		i++;
+	}
+	if (ft_getenv(str))
+		ft_unsetenv(str);
+	if (i != len)
+		str[i] = '=';
+}
+
+int
+	ft_setenv(char *str)
+{
+	t_list	*new;
+	char	*cpy;
+
+	if (!g_env || !str || !*str)
+		return (UTIL_ERROR);
+	delone_env(str);
+	if (!(cpy = ft_strdup(str)) || !(new = ft_lstnew(cpy)))
+	{
+		cpy ? FREE(cpy) : cpy;
+		return (UTIL_ERROR);
+	}
+	ft_lstadd_back(&g_env, new);
+	return (UTIL_SUCCESS);
 }
 
 int
@@ -29,7 +71,7 @@ int
 	size_t	len;
 
 	if (!g_env || !name || !*name)
-		return (ENVUTIL_ERROR);
+		return (UTIL_ERROR);
 	envptr = g_env;
 	prev = NULL;
 	len = ft_strlen(name);
@@ -43,10 +85,148 @@ int
 			else
 				g_env = envptr->next;
 			ft_lstdelone(envptr, free);
-			return (ENVUTIL_SUCCESS);
+			return (UTIL_SUCCESS);
 		}
 		prev = envptr;
 		envptr = envptr->next;
 	}
-	return (ENVUTIL_ERROR);
+	return (UTIL_ERROR);
+}
+
+static int
+	change_first_target_to_char(char *str, char target, char c)
+{
+	if (!str)
+		return (UTIL_ERROR);
+	while (*str)
+	{
+		if (*str == target)
+		{
+			*str = c;
+			return (UTIL_SUCCESS);
+		}
+		str++;
+	}
+	if (*str == target)
+	{
+		*str = c;
+		return (UTIL_SUCCESS);
+	}
+	return (UTIL_ERROR);
+}
+
+static void
+	env_merge_loop(t_list **left, t_list **right, t_list **next)
+{
+	int	l_flg;
+	int	r_flg;
+	int	comp;
+
+	l_flg = change_first_target_to_char((*left)->content, '=', '\0');
+	r_flg = change_first_target_to_char((*right)->content, '=', '\0');
+	comp = ft_strcmp((*left)->content, (*right)->content);
+	if (l_flg == UTIL_SUCCESS)
+		change_first_target_to_char((*left)->content, '\0', '=');
+	if (r_flg == UTIL_SUCCESS)
+		change_first_target_to_char((*right)->content, '\0', '=');
+	if (comp <= 0)
+	{
+		(*next)->next = *left;
+		*next = (*next)->next;
+		*left = (*left)->next;
+	}
+	else
+	{
+		(*next)->next = *right;
+		*next = (*next)->next;
+		*right = (*right)->next;
+	}
+}
+
+static t_list
+	*env_merge(t_list *left, t_list *right)
+{
+	t_list	head;
+	t_list	*next;
+
+	next = &head;
+	while (left && right)
+		env_merge_loop(&left, &right, &next);
+	if (!left)
+		next->next = right;
+	else
+		next->next = left;
+	return (head.next);
+}
+
+static t_list
+	*env_merge_sort_rec(t_list *lst)
+{
+	t_list	*left;
+	t_list	*right;
+	t_list	*right_head;
+
+	if (!lst || !lst->next)
+		return (lst);
+	left = lst;
+	right = lst->next;
+	if (right)
+		right = right->next;
+	while (right)
+	{
+		left = left->next;
+		right = right->next;
+		if (right)
+			right = right->next;
+	}
+	right_head = left->next;
+	left->next = NULL;
+	return (env_merge(env_merge_sort_rec(lst), env_merge_sort_rec(right_head)));
+}
+
+void
+	ft_envsort(t_list **lst)
+{
+	if (!lst)
+		return ;
+	*lst = env_merge_sort_rec(*lst);
+}
+
+void
+	ft_clear_copied_env(t_list **cpy)
+{
+	t_list	*tmp;
+
+	if (!cpy)
+		return ;
+	while (*cpy)
+	{
+		tmp = (*cpy)->next;
+		FREE(*cpy);
+		*cpy = tmp;
+	}
+}
+
+t_list
+	*ft_copy_env(void)
+{
+	t_list	*copy;
+	t_list	*envptr;
+	t_list	*current;
+
+	copy = NULL;
+	envptr = g_env;
+	while (envptr)
+	{
+		if (!(current = (t_list*)malloc(sizeof(t_list))))
+		{
+			ft_clear_copied_env(&copy);
+			return (NULL);
+		}
+		current->content = envptr->content;
+		current->next = NULL;
+		ft_lstadd_back(&copy, current);
+		envptr = envptr->next;
+	}
+	return (copy);
 }

--- a/srcs/export.c
+++ b/srcs/export.c
@@ -1,0 +1,174 @@
+#include "minishell_sikeda.h"
+
+static t_bool
+	validate_arg(char *arg)
+{
+	t_bool	ret;
+
+	ret = TRUE;
+	if (!arg)
+		return (ret);
+	if (!ft_isalpha(*arg) && *arg != '_')
+		return (FALSE);
+	arg++;
+	while (*arg && *arg != '=' && ret == TRUE)
+	{
+		if (!ft_isalnum(*arg) && *arg != '_')
+			ret = FALSE;
+		arg++;
+	}
+	return (ret);
+}
+
+static void
+	put_env_with_export_syntax(char *str, int fd)
+{
+	if (!str)
+		return ;
+	ft_putstr_fd("declare -x ", fd);
+	while (*str && *str != '=')
+		ft_putchar_fd(*str++, fd);
+	if (*str++ == '=')
+	{
+		ft_putstr_fd("=\"", fd);
+		while (*str)
+		{
+			if (*str == '"' || *str == '$' || *str == '\\' || *str == '`')
+				ft_putchar_fd('\\', fd);
+			ft_putchar_fd(*str++, fd);
+		}
+		ft_putstr_fd("\"\n", fd);
+	}
+	else
+		ft_putchar_fd('\n', fd);
+}
+
+static int
+	show_export(void)
+{
+	t_list	*copy_env;
+	t_list	*copy_env_head;
+
+	if (!(copy_env = ft_copy_env()))
+		return (UTIL_ERROR);
+	ft_envsort(&copy_env);
+	copy_env_head = copy_env;
+	while (copy_env)
+	{
+		put_env_with_export_syntax(copy_env->content, STDOUT_FILENO);
+		copy_env = copy_env->next;
+	}
+	ft_clear_copied_env(&copy_env_head);
+	return (UTIL_SUCCESS);
+}
+
+static int
+	exec_export(char **args)
+{
+	while (args[1])
+	{
+		if (!validate_arg(args[1]))
+		{
+			g_status = STATUS_GENERAL_ERR;
+			ft_put_cmderror_with_quoted_arg("export", CMD_IDENTIFIER_ERR, args[1]);
+		}
+		else if (ft_setenv(args[1]) == UTIL_ERROR)
+		{
+			g_status = STATUS_GENERAL_ERR;
+			ft_put_error(strerror(errno));
+			return (STOP);
+		}
+#ifdef EXPORTTEST
+		else
+			show_export();	// テスト用にexport実行
+#endif
+		args++;
+	}
+	return (KEEP_RUNNING);
+}
+
+int
+	ft_export(char **args)
+{
+	char	option[3];
+
+	g_status = STATUS_SUCCESS;
+	if (args[1] && !ft_strcmp(args[1], "--"))
+		args++;
+	else if (ft_get_cmd_option(option, args[1]))
+	{
+		g_status = STATUS_MISUSE_OF_BUILTINS_ERR;
+		ft_put_cmderror_with_arg("export", CMD_OPTION_ERR, option);
+		ft_put_cmderror_with_help("export", CMD_EXPORT_HELP);
+		return (KEEP_RUNNING);
+	}
+	if (!args[1] && show_export() == UTIL_ERROR)
+	{
+		g_status = STATUS_GENERAL_ERR;
+		ft_put_error(strerror(errno));
+		return (STOP);
+	}
+	return (exec_export(args));
+}
+
+#ifdef EXPORTTEST
+int
+	main(int ac, char **av)
+{
+	char	**args;
+	char	**args_head;
+	int		ret;
+	int		i;
+
+	if (ac < 2)
+	{
+		ft_put_error(strerror(EINVAL));
+		return (EXIT_FAILURE);
+	}
+	if (ft_init_env() == STOP)
+		return (EXIT_FAILURE);
+	if (ft_init_pwd() == STOP)
+	{
+		ft_lstclear(&g_env, free);
+		return (EXIT_FAILURE);
+	}
+	if (!(args = (char **)malloc(sizeof(char*) * (ac + 1))))
+	{
+		FREE(g_pwd);
+		ft_lstclear(&g_env, free);
+		return (EXIT_FAILURE);
+	}
+	i = -1;
+	while (++i < ac)
+		args[i] = av[i];
+	args[i] = NULL;
+	args_head = args;
+	ret = 0;
+	if (!ft_strcmp(args[1], "cd"))
+	{
+		++args;
+		ret = ft_pwd(args);	// test
+		ret = ft_cd(args);
+		ret = ft_pwd(args);	// test
+	}
+	else if (!ft_strcmp(args[1], "pwd"))
+		ret = ft_pwd(++args);
+	else if (!ft_strcmp(args[1], "env"))
+		ret = ft_env(++args);
+	else if (!ft_strcmp(args[1], "export"))
+		ret = ft_export(++args);
+	else if (!ft_strcmp(args[1], "unset"))
+		ret = ft_unset(++args);
+	else if (!ft_strcmp(args[1], "exit"))
+		ret = ft_exit(++args);
+	if (ret == STOP)
+	{
+		// TODO: exitが呼ばれたときにSTOPが返されてloopを終了してmainが終了するイメージ
+	}
+	FREE(args_head);
+	FREE(g_pwd);
+	ft_lstclear(&g_env, free);
+	// system("leaks export.out");
+	return (g_status);
+}
+#endif


### PR DESCRIPTION
# 概要
export関数作成 isuue #38

# 受入条件
内容確認、動作確認

# コメント
- ./exportttest.shにより、export.outが作成されるので 「./export.out export A=012」のように実行して頂くと試せます
- export.outは環境変数セット後に「export」を実行して環境変数一覧を表示し、環境変数のセットができているか確認できるようにしています。これを行うためexport.cの81~84行目がテスト用のコードになっています。
- ./exporttest.sh
  - exportが成功した場合、minihsellとbashそれぞれexportの結果をファイルに出力し、diffをとっています。
  - diffの結果以下のようになると思います
```
[mini] export
0
[bash] export
0
===diff check start===
19a20
> declare -x OLDPWD
29c30
< declare -x SHLVL="2"
---
> declare -x SHLVL="3"
42c43
< declare -x _="./export.out"
---
> declare -x _="/bin/bash"
===diff check end===
```
-
   - OLDPWDの結果が異なるのは既知の実装漏れです（issue #64 で対応します）
   - SHLVLはシェルの深さです。例えばbashの中でbashを起動、さらにその中でbashを起動、としていくたびにインクリメントします。このテストでは実行方法が違うので差異が出ます。
   - _は「$\_」とすると参照できるもので、「シェルスクリプト内で使った場合、起動されたシェルのファイル名。$0と同じ。それ以外の場合、直前に実行したコマンドの最後の引数。（引数が無かった場合はコマンド名）」となります。こちらもテストの実行方法が違うので差異が出ています。
- env_utils.cでft_envsort()という関数を作成し、t_listをマージソートしている部分があります。ここは[こちら](https://programming-place.net/ppp/contents/algorithm/sort/007.html)の「連結リストに対するマージソート」の項を参考にしました。

close #38