### PR TITLE
add #69 expand_env_var function

### DIFF
--- a/includes/minishell_tnishina.h
+++ b/includes/minishell_tnishina.h
@@ -8,8 +8,8 @@
 # include <stdio.h>
 # include <sys/wait.h>
 # include <unistd.h>
-# include <unistd.h>
 # include <string.h>
+# include "libft.h"
 
 /*
 ** basic parameters for minishell
@@ -42,5 +42,6 @@ typedef struct			s_command
 
 int		get_next_line(int fd, char **line);
 void	ft_free_str(char **str);
+t_list	*ft_make_token(char *line);
 
 #endif

--- a/make_token.sh
+++ b/make_token.sh
@@ -3,7 +3,7 @@
 cd libft
 make bonus
 cd ..
-gcc -g -Wall -Wextra -Werror -I./includes -I./libft srcs/make_token.c srcs/get_next_line.c -Llibft -lft -D TOKENTEST -o token.out
+gcc -g -Wall -Wextra -Werror -I./includes -I./libft srcs/env.c srcs/command_utils.c srcs/make_token.c srcs/get_next_line.c srcs/env_utils.c -Llibft -lft -D TOKENTEST -o token.out
 
 YELLOW=$(printf '\033[33m')
 CYAN=$(printf '\033[36m')


### PR DESCRIPTION
# 概要
トークンの中に環境変数が含まれていた場合に、それを展開して、連結リストをつなぎ直す関数を作成しています

# 受入条件
内容確認、動作確認

# コメント
- ft_getenvを使って、環境変数の展開を行っています
- bash make_token.shでtoken.outを作成していただいたあと、./token.outを実行していただくと、プロンプトが表示されます
- 一点、特にご相談したいのが、make_token.cの219~221行目の部分になります
- 現状、ft_getenvの中でft_strdupなどが失敗した場合やft_make_tokenの中でft_substrなどが失敗した場合と、環境変数に登録されていない変数名がft_getenvに渡された場合の処理が同じになっています
- ここの処理を書き分けるべきか、相談させていただきたいです (場合によっては、ft_getenvの方の実装を修正してもらう必要もあるかもしれないです)
- =~^+:,.等のenvkeyの終了文字については未対応 (#73 にて対応予定)