### PR TITLE
Feature/init oldpwd

### DIFF
--- a/envtest.sh
+++ b/envtest.sh
@@ -6,6 +6,7 @@ cd ..
 gcc -g -Wall -Wextra -Werror -I./includes -I./libft srcs/cd.c srcs/pwd.c srcs/exit.c srcs/env.c srcs/command_utils.c srcs/env_utils.c -Llibft -lft -D ENVTEST -o env.out
 
 YELLOW=$(printf '\033[33m')
+CYAN=$(printf '\033[36m')
 RESET=$(printf '\033[0m')
 
 printf "${YELLOW}%s${RESET}\n" "[mini] env"
@@ -31,6 +32,50 @@ printf "${YELLOW}%s${RESET}\n" "[mini] env --"
 echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] env --"
 echo "env > bash_env --" | bash
+echo $?
+# _=で始まる変数は最後に実行したコマンドの引数で、bashとminishellの呼び出し方が異なるので、この値も異なるため除外する
+sed -e '/^_=/d' mini_env > mini_env_sed
+sed -e '/^_=/d' bash_env > bash_env_sed
+# 順番を同じにすることができない（?）ので文字数で比較
+cat mini_env_sed | wc > mini_env_wc
+cat bash_env_sed | wc > bash_env_wc
+echo "===diff check start==="
+diff mini_env_wc bash_env_wc
+echo "===diff check end==="
+rm mini_env mini_env_sed mini_env_wc bash_env bash_env_sed bash_env_wc
+echo
+
+printf "${CYAN}%s${RESET}\n" "export ENVTEST=0123"
+export ENVTEST=0123
+printf "${YELLOW}%s${RESET}\n" "[mini] env"
+./env.out env > mini_env
+echo $?
+printf "${CYAN}%s${RESET}\n" "export ENVTEST=0123"
+export ENVTEST=0123
+printf "${YELLOW}%s${RESET}\n" "[bash] env"
+echo "env > bash_env" | bash
+echo $?
+# _=で始まる変数は最後に実行したコマンドの引数で、bashとminishellの呼び出し方が異なるので、この値も異なるため除外する
+sed -e '/^_=/d' mini_env > mini_env_sed
+sed -e '/^_=/d' bash_env > bash_env_sed
+# 順番を同じにすることができない（?）ので文字数で比較
+cat mini_env_sed | wc > mini_env_wc
+cat bash_env_sed | wc > bash_env_wc
+echo "===diff check start==="
+diff mini_env_wc bash_env_wc
+echo "===diff check end==="
+rm mini_env mini_env_sed mini_env_wc bash_env bash_env_sed bash_env_wc
+echo
+
+printf "${CYAN}%s${RESET}\n" "export ENVTEST"
+export ENVTEST
+printf "${YELLOW}%s${RESET}\n" "[mini] env"
+./env.out env > mini_env
+echo $?
+printf "${CYAN}%s${RESET}\n" "export ENVTEST"
+export ENVTEST
+printf "${YELLOW}%s${RESET}\n" "[bash] env"
+echo "env > bash_env" | bash
 echo $?
 # _=で始まる変数は最後に実行したコマンドの引数で、bashとminishellの呼び出し方が異なるので、この値も異なるため除外する
 sed -e '/^_=/d' mini_env > mini_env_sed

--- a/exporttest.sh
+++ b/exporttest.sh
@@ -324,3 +324,35 @@ diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
 echo
+
+# OLDPWDにexportで値を設定
+printf "${YELLOW}%s${RESET}\n" "[mini] export OLDPWD=override_oldpwd"
+./export.out export OLDPWD=override_oldpwd > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export OLDPWD=override_oldpwd"
+echo "export OLDPWD=override_oldpwd" | bash
+echo $?
+echo "export OLDPWD=override_oldpwd ; export > bash_export" | bash
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+
+# PWDがunsetされた状態でminishell起動
+# シェル起動時にカレントディレクトリパスを値にしてPWD作成する（未実装のためdiff出る）
+printf "${CYAN}%s${RESET}\n" "unset PWD"
+unset PWD
+printf "${YELLOW}%s${RESET}\n" "[mini] export"
+./export.out export > mini_export
+echo $?
+printf "${CYAN}%s${RESET}\n" "unset PWD"
+unset PWD
+printf "${YELLOW}%s${RESET}\n" "[bash] export"
+echo "export > bash_export" | bash
+echo $?
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo

--- a/includes/minishell_sikeda.h
+++ b/includes/minishell_sikeda.h
@@ -79,6 +79,10 @@ int		ft_cd(char **args);
 int		ft_init_pwd(void);
 int		ft_pwd(char **args);
 /*
+** export.c
+*/
+int		ft_export(char **args);
+/*
 ** unset.c
 */
 int		ft_unset(char **args);

--- a/srcs/env.c
+++ b/srcs/env.c
@@ -115,7 +115,8 @@ int
 		envptr = g_env;
 		while (envptr)
 		{
-			ft_putendl_fd(envptr->content, STDOUT_FILENO);
+			if (ft_strchr(envptr->content, '='))
+				ft_putendl_fd(envptr->content, STDOUT_FILENO);
 			envptr = envptr->next;
 		}
 	}

--- a/srcs/env.c
+++ b/srcs/env.c
@@ -1,11 +1,28 @@
 #include "../includes/minishell_sikeda.h"
 
+static int
+	init_env_list(char *current, int i)
+{
+	t_list	*new;
+	char	*cpy;
+
+	if (!(cpy = ft_strdup(current)) || !(new = ft_lstnew(cpy)))
+	{
+		cpy ? FREE(cpy) : cpy;
+		ft_lstclear(&g_env, free);
+		return (STOP);
+	}
+	if (i == 0)
+		g_env = new;
+	else
+		ft_lstadd_back(&g_env, new);
+	return (KEEP_RUNNING);
+}
+
 int
 	ft_init_env(void)
 {
 	extern char	**environ;
-	t_list		*new;
-	char		*cpy;
 	int			i;
 
 	i = 0;
@@ -16,18 +33,12 @@ int
 			i++;
 			continue ;
 		}
-		if (!(cpy = ft_strdup(environ[i])) || !(new = ft_lstnew(cpy)))
-		{
-			cpy ? FREE(cpy) : cpy;
-			ft_lstclear(&g_env, free);
+		if (init_env_list(environ[i], i) == STOP)
 			return (STOP);
-		}
-		if (i == 0)
-			g_env = new;
-		else
-			ft_lstadd_back(&g_env, new);
 		i++;
 	}
+	if (init_env_list("OLDPWD", i++) == STOP)
+		return (STOP);
 	return (KEEP_RUNNING);
 }
 

--- a/srcs/env_utils.c
+++ b/srcs/env_utils.c
@@ -25,6 +25,7 @@ char
 static void
 	delone_env(char *str)
 {
+	char	*env;
 	size_t	len;
 	size_t	i;
 
@@ -39,8 +40,9 @@ static void
 		}
 		i++;
 	}
-	if (ft_getenv(str))
+	if ((env = ft_getenv(str)))
 		ft_unsetenv(str);
+	FREE(env);
 	if (i != len)
 		str[i] = '=';
 }
@@ -78,7 +80,8 @@ int
 	while (envptr)
 	{
 		if (!ft_strncmp(name, envptr->content, len)
-		&& ((char*)envptr->content)[len] == '=')
+		&& (((char*)envptr->content)[len] == '='
+		|| ((char*)envptr->content)[len] == '\0'))
 		{
 			if (prev)
 				prev->next = envptr->next;

--- a/srcs/env_utils.c
+++ b/srcs/env_utils.c
@@ -25,7 +25,6 @@ char
 static void
 	delone_env(char *str)
 {
-	char	*env;
 	size_t	len;
 	size_t	i;
 
@@ -40,9 +39,8 @@ static void
 		}
 		i++;
 	}
-	if ((env = ft_getenv(str)))
+	if (ft_getenv(str))
 		ft_unsetenv(str);
-	FREE(env);
 	if (i != len)
 		str[i] = '=';
 }

--- a/srcs/env_utils.c
+++ b/srcs/env_utils.c
@@ -218,13 +218,11 @@ t_list
 	envptr = g_env;
 	while (envptr)
 	{
-		if (!(current = (t_list*)malloc(sizeof(t_list))))
+		if (!(current = ft_lstnew(envptr->content)))
 		{
 			ft_clear_copied_env(&copy);
 			return (NULL);
 		}
-		current->content = envptr->content;
-		current->next = NULL;
 		ft_lstadd_back(&copy, current);
 		envptr = envptr->next;
 	}


### PR DESCRIPTION
# 概要
- #74 ft_copy_envをft_litnewを使用してリライト
- #63 ビルトインコマンドenvが値のみの環境変数を表示しないように
- #64 環境変数OLDPWDをminishell起動時に値なしでnameのみセット

# 受入条件
内容確認、動作確認（envtest.sh, exporttest.sh）

# コメント
- exporttest.shで出ていたOLDPWDのdiffが出なくなっているはずです
- exporttest.shの最後のテストではPWDのテストをしていますが、こちらも対応しなければいけないのでイシューを作りました #78 今後対応します
- env_utils.cのdelone_envの修正はft_getenvでmallocされたもののfreeがなくリークしていたので修正しました
- env_utils.cのft_unsetenvの修正はnameのみの環境変数への対応です

close #74 
close #63
close #64