### PR TITLE
add #17 do_simple_pipe_function

### DIFF
--- a/includes/minishell_tnishina.h
+++ b/includes/minishell_tnishina.h
@@ -41,8 +41,10 @@ typedef struct			s_command
 	struct s_command	*next;
 }						t_command;
 
-int		get_next_line(int fd, char **line);
-void	ft_free_str(char **str);
-t_list	*ft_make_token(char *line);
+int			get_next_line(int fd, char **line);
+void		ft_free_str(char **str);
+t_list		*ft_make_token(char *line);
+t_command	*ft_make_command(t_list *tokens);
+void		ft_clear_commands(t_command **c);
 
 #endif

--- a/pipetest.sh
+++ b/pipetest.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+cd libft
+make bonus
+cd ..
+gcc -g -Wall -Wextra -Werror -I./includes -I./libft srcs/pwd.c srcs/command_utils.c srcs/env.c srcs/env_utils.c srcs/minishell.c srcs/make_command.c srcs/make_token.c srcs/get_next_line.c -Llibft -lft -o pipe.out
+
+YELLOW=$(printf '\033[33m')
+CYAN=$(printf '\033[36m')
+RESET=$(printf '\033[0m')
+
+#printf "\n${CYAN}%s${RESET}\n\n" "***Test starts***"
+
+#printf "${YELLOW}%s${RESET}\n\n" "ls | grep e; echo \$HOME"
+#./pipe.out "ls | grep e; echo \$HOME"
+#echo
+
+#printf "${YELLOW}%s${RESET}\n\n" "test;test;test;test;"
+#./command.out "test;test;test;test;"
+#echo
+
+#printf "${YELLOW}%s${RESET}\n\n" "test| test&test>test<;"
+#./command.out "test| test&test>test<;"
+#echo

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -10,14 +10,77 @@ int
 }
 
 void
-	do_command(char *line, char **environ)
+	do_command(t_command *c, char **environ)
 {
 	char	**argv;
+	char	**head;
+	char	*tmp;
 
-	argv = ft_split(line, ' ');
-	argv[0] = ft_strjoin("/bin/", argv[0]);
-	execve(argv[0], argv, environ);
-	exit_with_error("execve");
+	if (!c || !environ)
+		exit(1);
+	if (!(argv = (char**)malloc(sizeof(char*) * (ft_lstsize(c->args) + 1))))
+		exit(1);
+	head = argv;
+	while (c->args)
+	{
+		*argv = c->args->content;
+		argv++;
+		c->args = c->args->next;
+	}
+	*argv = NULL;
+	argv = head;
+	tmp = argv[0];
+	if (!(argv[0] = ft_strjoin("/bin/", argv[0])))
+		exit_with_error("malloc");
+	FREE(tmp);
+	if (execve(argv[0], argv, environ) < 0)
+	{
+		tmp = argv[0];
+		if (!(argv[0] = ft_strjoin("/usr", argv[0])))
+			exit_with_error("malloc");
+		FREE(tmp);
+		if (execve(argv[0], argv, environ) < 0)
+			exit_with_error("execve");
+	}
+}
+
+static void
+	close_n_wait(int pipefd[2], pid_t childs[2], int *status, int *res)
+{
+	close(pipefd[0]);
+	close(pipefd[1]);
+	*res = waitpid(childs[0], status, 0);
+	*res = waitpid(childs[1], status, 0);
+}
+
+static void
+	do_simple_pipe(t_command *commands, char **environ)
+{
+	int		pipefd[2];
+	int		res;
+	int		status;
+	pid_t	childs[2];
+
+	res = pipe(pipefd);
+	if ((childs[0] = fork()) < 0)
+		exit_with_error("fork");
+	else if (childs[0] == 0)
+	{
+		close(pipefd[0]);
+		dup2(pipefd[1], 1);
+		close(pipefd[1]);
+		do_command(commands, environ);
+	}
+	if ((childs[1] = fork()) < 0)
+		exit_with_error("fork");
+	else if (childs[1] == 0)
+	{
+		close(pipefd[1]);
+		dup2(pipefd[0], 0);
+		close(pipefd[0]);
+		do_command(commands->next, environ);
+	}
+	close_n_wait(pipefd, childs, &status, &res);
 }
 
 int
@@ -27,21 +90,54 @@ int
 	pid_t		pid;
 	int			status;
 	extern char	**environ;
+	t_list		*tokens;
+	t_command	*head;
+	t_command	*commands;
 
+	if (ft_init_env() == STOP)
+		return (EXIT_FAILURE);
+	if (ft_init_pwd() == STOP)
+	{
+		ft_lstclear(&g_env, free);
+		return (EXIT_FAILURE);
+	}
 	ft_putstr_fd(PROMPT, STDOUT_FILENO);
 	while (get_next_line(STDIN_FILENO, &line) == 1 &&
 		ft_strncmp(line, "exit", 5))
 	{
-		if ((pid = fork()) < 0)
-			exit_with_error("fork");
-		else if (pid == 0)
-			do_command(line, environ);
-		if ((pid = waitpid(pid, &status, 0)) < 0)
-			exit_with_error("wait");
+		if (!(tokens = ft_make_token(line)) || !(commands = ft_make_command(tokens)))
+		{
+			FREE(line);
+			ft_lstclear(&tokens, free);
+			return (1);
+		}
+		head = commands;
+		while (commands)
+		{
+			if (!ft_strncmp(commands->op, ";", 1))
+			{
+				if ((pid = fork()) < 0)
+					exit_with_error("fork");
+				else if (pid == 0)
+					do_command(commands, environ);
+				if ((pid = waitpid(pid, &status, 0)) < 0)
+					exit_with_error("wait");
+				commands = commands->next;
+			}
+			else if (!ft_strncmp(commands->op, "|", 1))
+			{
+				do_simple_pipe(commands, environ);
+				commands = commands->next->next;
+			}
+		}
 		FREE(line);
+		get_next_line(STDIN_FILENO, NULL);
+		ft_clear_commands(&head);
 		ft_putstr_fd(PROMPT, STDOUT_FILENO);
 	}
 	FREE(line);
+	get_next_line(STDIN_FILENO, NULL);
+	FREE(g_pwd);
 	ft_putstr_fd(EXIT_PROMPT, STDOUT_FILENO);
 	exit(0);
 }

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -138,6 +138,7 @@ int
 	FREE(line);
 	get_next_line(STDIN_FILENO, NULL);
 	FREE(g_pwd);
+	ft_lstclear(&g_env, free);
 	ft_putstr_fd(EXIT_PROMPT, STDOUT_FILENO);
 	exit(0);
 }


### PR DESCRIPTION
# 概要
シンプルなパイプを実装してみました

# 受入条件
動作確認、内容確認

# コメント
- 一段のパイプのみをまずは実装してみました
- bash pipetest.shでpipe.outが作られるので、./pipe.outで起動して、触ってみてもらえるとありがたいです
- normについては多段パイプの実装時にまとめて対応しようと思い、まだ対応していません
- ひとまず、池田さんに作って頂いている関数以外のexecveで動く関数を使用する場合のみ実装しています
- Discordでも頭出しさせて頂きましたが、コマンド構造体のargsに入っている内容をsplit型のchar**にコピーしてから渡す、という形にしています
- 一部still reachableのリークが残っているのですが、ft_init_env関連のようなので、一旦これで確認頂いて、多段パイプの実装の際に合わせて確認しようと思います

close #17 