### PR TITLE
update #78 PWD to set when shell start

### DIFF
--- a/envtest.sh
+++ b/envtest.sh
@@ -89,6 +89,50 @@ echo "===diff check end==="
 rm mini_env mini_env_sed mini_env_wc bash_env bash_env_sed bash_env_wc
 echo
 
+printf "${CYAN}%s${RESET}\n" "unset PWD"
+unset PWD
+printf "${YELLOW}%s${RESET}\n" "[mini] env"
+./env.out env > mini_env
+echo $?
+printf "${CYAN}%s${RESET}\n" "unset PWD"
+unset PWD
+printf "${YELLOW}%s${RESET}\n" "[bash] env"
+echo "env > bash_env" | bash
+echo $?
+# _=で始まる変数は最後に実行したコマンドの引数で、bashとminishellの呼び出し方が異なるので、この値も異なるため除外する
+sed -e '/^_=/d' mini_env > mini_env_sed
+sed -e '/^_=/d' bash_env > bash_env_sed
+# 順番を同じにすることができない（?）ので文字数で比較
+cat mini_env_sed | wc > mini_env_wc
+cat bash_env_sed | wc > bash_env_wc
+echo "===diff check start==="
+diff mini_env_wc bash_env_wc
+echo "===diff check end==="
+rm mini_env mini_env_sed mini_env_wc bash_env bash_env_sed bash_env_wc
+echo
+
+printf "${CYAN}%s${RESET}\n" "export PWD=hello"
+export PWD=hello
+printf "${YELLOW}%s${RESET}\n" "[mini] env"
+./env.out env > mini_env
+echo $?
+printf "${CYAN}%s${RESET}\n" "export PWD=hello"
+export PWD=hello
+printf "${YELLOW}%s${RESET}\n" "[bash] env"
+echo "env > bash_env" | bash
+echo $?
+# _=で始まる変数は最後に実行したコマンドの引数で、bashとminishellの呼び出し方が異なるので、この値も異なるため除外する
+sed -e '/^_=/d' mini_env > mini_env_sed
+sed -e '/^_=/d' bash_env > bash_env_sed
+# 順番を同じにすることができない（?）ので文字数で比較
+cat mini_env_sed | wc > mini_env_wc
+cat bash_env_sed | wc > bash_env_wc
+echo "===diff check start==="
+diff mini_env_wc bash_env_wc
+echo "===diff check end==="
+rm mini_env mini_env_sed mini_env_wc bash_env bash_env_sed bash_env_wc
+echo
+
 printf "${YELLOW}%s${RESET}\n" "[mini] env -a"
 ./env.out env -a
 echo $?

--- a/exporttest.sh
+++ b/exporttest.sh
@@ -340,7 +340,6 @@ rm mini_export bash_export
 echo
 
 # PWDがunsetされた状態でminishell起動
-# シェル起動時にカレントディレクトリパスを値にしてPWD作成する（未実装のためdiff出る）
 printf "${CYAN}%s${RESET}\n" "unset PWD"
 unset PWD
 printf "${YELLOW}%s${RESET}\n" "[mini] export"

--- a/includes/minishell_sikeda.h
+++ b/includes/minishell_sikeda.h
@@ -53,6 +53,7 @@ t_list	*g_env;
 char	*ft_getenv(const char *name);
 int		ft_unsetenv(const char *name);
 int		ft_setenv(char *str);
+int		ft_setenv_sep(char *name, char *value);
 int		ft_unsetenv(const char *name);
 void	ft_envsort(t_list **lst);
 void	ft_clear_copied_env(t_list **cpy);

--- a/pwdtest.sh
+++ b/pwdtest.sh
@@ -3,9 +3,10 @@
 cd libft
 make bonus
 cd ..
-gcc -Wall -Wextra -Werror -I./includes -I./libft srcs/cd.c srcs/pwd.c srcs/exit.c srcs/env.c srcs/command_utils.c srcs/env_utils.c -Llibft -lft -D PWDTEST -o pwd.out
+gcc -g -Wall -Wextra -Werror -I./includes -I./libft srcs/cd.c srcs/pwd.c srcs/exit.c srcs/env.c srcs/unset.c srcs/export.c srcs/command_utils.c srcs/env_utils.c -Llibft -lft -D PWDTEST -o pwd.out
 
 YELLOW=$(printf '\033[33m')
+CYAN=$(printf '\033[36m')
 RESET=$(printf '\033[0m')
 
 WORKDIR=`pwd`
@@ -17,80 +18,151 @@ echo
 printf "${YELLOW}%s${RESET}\n" "[mini] pwd"
 export PWD=hello
 ./pwd.out pwd
+echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] pwd"
 export PWD=hello
 pwd
+echo $?
 echo
 
 printf "${YELLOW}%s${RESET}\n" "[mini] pwd ~"
 ./pwd.out pwd ~
+echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] pwd ~"
 pwd ~
+echo $?
 echo
 
 printf "${YELLOW}%s${RESET}\n" "[mini] pwd \"~\""
 ./pwd.out pwd "~"
+echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] pwd \"~\""
 pwd "~"
+echo $?
 echo
 
 printf "${YELLOW}%s${RESET}\n" "[mini] pwd \"\""
-./pwd.out pwd "~"
+./pwd.out pwd ""
+echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] pwd \"\""
 pwd ""
+echo $?
 echo
 
 printf "${YELLOW}%s${RESET}\n" "[mini] pwd ''"
 ./pwd.out pwd ''
+echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] pwd ''"
 pwd ''
+echo $?
 echo
 
 printf "${YELLOW}%s${RESET}\n" "[mini] pwd \$HOME"
 ./pwd.out pwd $HOME
+echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] pwd \$HOME"
 pwd $HOME
+echo $?
 echo
 
 printf "${YELLOW}%s${RESET}\n" "[mini] pwd hoge"
 ./pwd.out pwd hoge
+echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] pwd hoge"
 pwd hoge
+echo $?
 echo
 
-printf "${YELLOW}%s${RESET}\n" "mkdir pwdtest"
+printf "${CYAN}%s${RESET}\n" "mkdir pwdtest"
 mkdir pwdtest
 printf "${YELLOW}%s${RESET}\n" "[mini] pwd; cd pwdtest; pwd"
 ./pwd.out cd pwdtest
+echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] pwd; cd pwdtest; pwd"
 pwd
 cd pwdtest
 pwd
+echo $?
 echo
 cd $WORKDIR
+rm -rf pwdtest
+
+printf "${CYAN}%s${RESET}\n" "mkdir pwdtest"
+mkdir pwdtest
+printf "${CYAN}%s${RESET}\n" "unset PWD"
+unset PWD
+printf "${YELLOW}%s${RESET}\n" "[mini] pwd; cd pwdtest; pwd"
+./pwd.out cd pwdtest
+echo $?
+printf "${CYAN}%s${RESET}\n" "unset PWD"
+unset PWD
+printf "${YELLOW}%s${RESET}\n" "[bash] pwd; cd pwdtest; pwd"
+pwd
+cd pwdtest
+pwd
+echo $?
+echo
+cd $WORKDIR
+rm -rf pwdtest
+
+printf "${CYAN}%s${RESET}\n" "mkdir pwdtest"
+mkdir pwdtest
+printf "${CYAN}%s${RESET}\n" "export PWD=/Users"
+export PWD=/Users
+printf "${YELLOW}%s${RESET}\n" "[mini] pwd; cd pwdtest; pwd"
+./pwd.out cd pwdtest
+echo $?
+printf "${CYAN}%s${RESET}\n" "export PWD=/Users"
+export PWD=/Users
+printf "${YELLOW}%s${RESET}\n" "[bash] pwd; cd pwdtest; pwd"
+pwd
+cd pwdtest
+pwd
+echo $?
+echo
+cd $WORKDIR
+rm -rf pwdtest
 
 printf "${YELLOW}%s${RESET}\n" "[mini] pwd hoge world"
 ./pwd.out pwd hoge world
+echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] pwd hoge world"
 pwd hoge world
+echo $?
 echo
 
 printf "${YELLOW}%s${RESET}\n" "[mini] pwd -"
 ./pwd.out pwd -
+echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] pwd -"
 pwd -
+echo $?
+echo
+
+# TODO: 未対応
+echo "※今後対応予定です"
+printf "${YELLOW}%s${RESET}\n" "[mini] pwd --"
+./pwd.out pwd --
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] pwd --"
+pwd --
+echo $?
 echo
 
 printf "${YELLOW}%s${RESET}\n" "[mini] pwd -a"
 ./pwd.out pwd -a
+echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] pwd -a"
 pwd -a
+echo $?
 echo
 
 printf "${YELLOW}%s${RESET}\n" "[mini] pwd --version"
 ./pwd.out pwd --version
+echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] pwd --version"
 pwd --version
+echo $?
 echo
 
 rm -rf pwdtest

--- a/srcs/env_utils.c
+++ b/srcs/env_utils.c
@@ -64,6 +64,30 @@ int
 }
 
 int
+	ft_setenv_sep(char *name, char *value)
+{
+	char	*equal_value;
+	char	*env_str;
+	int		ret;
+
+	if (!g_env || !name)
+		return (UTIL_ERROR);
+	equal_value = NULL;
+	if (value && !(equal_value = ft_strjoin("=", value)))
+		return (UTIL_ERROR);
+	if (equal_value)
+		env_str = ft_strjoin(name, equal_value);
+	else
+		env_str = ft_strdup(name);
+	ret = UTIL_ERROR;
+	if (env_str)
+		ret = ft_setenv(env_str);
+	FREE(equal_value);
+	FREE(env_str);
+	return (ret);
+}
+
+int
 	ft_unsetenv(const char *name)
 {
 	t_list	*envptr;

--- a/srcs/pwd.c
+++ b/srcs/pwd.c
@@ -6,19 +6,12 @@ extern char
 int
 	ft_init_pwd(void)
 {
-	int	fd;
-
-	if ((g_pwd = ft_strdup(ft_getenv("PWD"))))
-		if (0 <= (fd = open(g_pwd, O_RDONLY)) && close(fd) <= 0)
-			return (KEEP_RUNNING);
-	FREE(g_pwd);
 	if (!(g_pwd = getcwd(NULL, 0)))
 	{
-		// TODO: エラーステータス設定
-		ft_putendl_fd(strerror(errno), STDERR_FILENO);
+		ft_put_error(strerror(errno));
 		return (STOP);
 	}
-	// TODO: $PWDの値を更新
+	ft_setenv_sep("PWD", g_pwd);
 	return (KEEP_RUNNING);
 }
 
@@ -27,9 +20,10 @@ int
 {
 	char	option[3];
 
+	g_status = STATUS_SUCCESS;
 	if (ft_get_cmd_option(option, args[1]))
 	{
-		// TODO: エラーステータス設定
+		g_status = STATUS_GENERAL_ERR;
 		ft_put_cmderror_with_arg("pwd", CMD_OPTION_ERR, option);
 		ft_put_cmderror_with_help("pwd", CMD_PWD_HELP);
 	}
@@ -74,14 +68,18 @@ int
 	if (!ft_strcmp(args[1], "cd"))
 	{
 		++args;
-		ret = ft_pwd(args);
+		ret = ft_pwd(args);	// test
 		ret = ft_cd(args);
-		ret = ft_pwd(args);
+		ret = ft_pwd(args);	// test
 	}
 	else if (!ft_strcmp(args[1], "pwd"))
 		ret = ft_pwd(++args);
 	else if (!ft_strcmp(args[1], "env"))
 		ret = ft_env(++args);
+	else if (!ft_strcmp(args[1], "export"))
+		ret = ft_export(++args);
+	else if (!ft_strcmp(args[1], "unset"))
+		ret = ft_unset(++args);
 	else if (!ft_strcmp(args[1], "exit"))
 		ret = ft_exit(++args);
 	if (ret == STOP)
@@ -92,6 +90,6 @@ int
 	FREE(g_pwd);
 	ft_lstclear(&g_env, free);
 	// system("leaks pwd.out");
-	return (EXIT_SUCCESS);
+	return (g_status);
 }
 #endif

--- a/srcs/pwd.c
+++ b/srcs/pwd.c
@@ -6,12 +6,13 @@ extern char
 int
 	ft_init_pwd(void)
 {
-	if (!(g_pwd = getcwd(NULL, 0)))
+	if (!(g_pwd = getcwd(NULL, 0))
+	|| ft_setenv_sep("PWD", g_pwd) == UTIL_ERROR)
 	{
 		ft_put_error(strerror(errno));
+		FREE(g_pwd);
 		return (STOP);
 	}
-	ft_setenv_sep("PWD", g_pwd);
 	return (KEEP_RUNNING);
 }
 


### PR DESCRIPTION
# 概要
issue #78 シェル起動時にPWDの値を設定

# 受入条件
内容確認、動作確認（pwdtest.sh, envtest.sh, exporttest.sh）

# コメント
- このコミットにより、exporttest.shの最後のテストでPWDのdiffが出ないようになりました。
- pwdtest.sh, envtest.shには今回のコミットを行わなければdiffが出るパターンのテストを追加しました（環境変数PWDを削除/変更してからmnishell起動するテスト）

close #78