### PR TITLE
update #80 processing of the pwd function when it has -- argument

### DIFF
--- a/pwdtest.sh
+++ b/pwdtest.sh
@@ -139,8 +139,6 @@ pwd -
 echo $?
 echo
 
-# TODO: 未対応
-echo "※今後対応予定です"
 printf "${YELLOW}%s${RESET}\n" "[mini] pwd --"
 ./pwd.out pwd --
 echo $?
@@ -154,6 +152,14 @@ printf "${YELLOW}%s${RESET}\n" "[mini] pwd -a"
 echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] pwd -a"
 pwd -a
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] pwd -- -a"
+./pwd.out pwd -- -a
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] pwd -- -a"
+pwd -- -a
 echo $?
 echo
 

--- a/srcs/pwd.c
+++ b/srcs/pwd.c
@@ -22,14 +22,16 @@ int
 	char	option[3];
 
 	g_status = STATUS_SUCCESS;
-	if (ft_get_cmd_option(option, args[1]))
+	if (args[1] && !ft_strcmp(args[1], "--"))
+		args++;
+	else if (ft_get_cmd_option(option, args[1]))
 	{
 		g_status = STATUS_GENERAL_ERR;
 		ft_put_cmderror_with_arg("pwd", CMD_OPTION_ERR, option);
 		ft_put_cmderror_with_help("pwd", CMD_PWD_HELP);
+		return (KEEP_RUNNING);
 	}
-	else
-		ft_putendl_fd(g_pwd, STDOUT_FILENO);
+	ft_putendl_fd(g_pwd, STDOUT_FILENO);
 	return (KEEP_RUNNING);
 }
 


### PR DESCRIPTION
# 概要
issue #80 pwd関数の引数に"--"がある場合にpwdを正常実行する

# 受入条件
内容確認、動作確認（pwdtest.sh）

# コメント
pwdの引数に"--"がある場合に引数エラーを出していたところを修正しました

close #80