### PR TITLE
Feature/update exit

### DIFF
--- a/exittest.sh
+++ b/exittest.sh
@@ -127,24 +127,6 @@ echo "exit 0" | bash
 echo $?
 echo
 
-printf "${YELLOW}%s${RESET}\n" "[mini] exit 9223372036854775807"
-./exit.out exit 9223372036854775807
-echo $?
-printf "${YELLOW}%s${RESET}\n" "[bash] exit 9223372036854775807"
-echo "exit 9223372036854775807" | bash
-echo $?
-echo
-
-# TODO: 未対応
-echo "※今後対応予定です"
-printf "${YELLOW}%s${RESET}\n" "[mini] exit 9223372036854775808"
-./exit.out exit 9223372036854775808
-echo $?
-printf "${YELLOW}%s${RESET}\n" "[bash] exit 9223372036854775808"
-echo "exit 9223372036854775808" | bash
-echo $?
-echo
-
 printf "${YELLOW}%s${RESET}\n" "[mini] exit +100"
 ./exit.out exit +100
 echo $?
@@ -222,6 +204,38 @@ printf "${YELLOW}%s${RESET}\n" "[mini] exit 2147483650"
 echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] exit 2147483650"
 echo "exit 2147483650" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit 9223372036854775807"
+./exit.out exit 9223372036854775807
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit 9223372036854775807"
+echo "exit 9223372036854775807" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit 9223372036854775808"
+./exit.out exit 9223372036854775808
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit 9223372036854775808"
+echo "exit 9223372036854775808" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit -9223372036854775808"
+./exit.out exit -9223372036854775808
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit -9223372036854775808"
+echo "exit -9223372036854775808" | bash
+echo $?
+echo
+
+printf "${YELLOW}%s${RESET}\n" "[mini] exit -9223372036854775809"
+./exit.out exit -9223372036854775809
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] exit -9223372036854775809"
+echo "exit -9223372036854775809" | bash
 echo $?
 echo
 

--- a/includes/minishell_sikeda.h
+++ b/includes/minishell_sikeda.h
@@ -64,6 +64,7 @@ t_list	*ft_copy_env(void);
 int		ft_strcmp(const char *s1, const char *s2);
 int		ft_isspace(char c);
 int		ft_isnumeric(char *s);
+int		ft_isover_llrange(char *s);
 char	*ft_get_cmd_option(char *option, const char *arg);
 void	ft_put_error(char *msg);
 void	ft_put_cmderror(char *cmd_name, char *msg);

--- a/srcs/command_utils.c
+++ b/srcs/command_utils.c
@@ -36,6 +36,30 @@ int
 	return (1);
 }
 
+int
+	ft_isover_llrange(char *s)
+{
+	size_t	num;
+	int		is_minus;
+
+	while (ft_isspace(*s))
+		s++;
+	is_minus = *s == '-' ? 1 : 0;
+	if (*s == '+' || *s == '-')
+		s++;
+	num = 0;
+	while (ft_isdigit(*s))
+	{
+		num = num * 10 + *s - '0';
+		if (is_minus && (size_t)__LONG_LONG_MAX__ + 1 < num)
+			return (-1);
+		else if (!is_minus && (size_t)__LONG_LONG_MAX__ < num)
+			return (1);
+		s++;
+	}
+	return (0);
+}
+
 char
 	*ft_get_cmd_option(char *option, const char *arg)
 {

--- a/srcs/exit.c
+++ b/srcs/exit.c
@@ -10,7 +10,7 @@ static int
 		ft_put_cmderror("exit", strerror(errno));
 		return (STOP);
 	}
-	if (ft_isnumeric(trimmed_arg))
+	if (ft_isnumeric(trimmed_arg) && !ft_isover_llrange(trimmed_arg))
 	{
 		g_status = (uint8_t)ft_atoi(trimmed_arg);
 		if (args[2])

--- a/srcs/exit.c
+++ b/srcs/exit.c
@@ -7,7 +7,7 @@ static int
 
 	if (!(trimmed_arg = ft_strtrim(args[1], SPACE_CHARS)))
 	{
-		ft_put_cmderror("exit", strerror(errno));
+		ft_put_error(strerror(errno));
 		return (STOP);
 	}
 	if (ft_isnumeric(trimmed_arg) && !ft_isover_llrange(trimmed_arg))

--- a/srcs/exit.c
+++ b/srcs/exit.c
@@ -33,7 +33,6 @@ static int
 int
 	ft_exit(char **args)
 {
-	g_status = STATUS_SUCCESS;
 	ft_putendl_fd("exit", STDERR_FILENO);
 	if (args[1])
 	{


### PR DESCRIPTION
# 概要
issue #99 引数なしのexitは直前コマンドの終了ステータスで終了する（exitが正常終了だからといって0を設定しない）
issue #55 引数がLongLongの範囲を超えていたら数字として処理しない

# 受入条件
内容確認、動作確認（exittest.sh）

# コメント
- exittest.shにテストケースを追加しました

close #99 
close #55 