### PR TITLE
Feature/update export

### DIFF
--- a/exporttest.sh
+++ b/exporttest.sh
@@ -251,13 +251,26 @@ echo "===diff check end==="
 rm mini_export bash_export
 echo
 
+printf "${YELLOW}%s${RESET}\n" "[mini] export EXPORTTEST=\" hello\""
+./export.out export EXPORTTEST=" hello" > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export EXPORTTEST=\" hello\""
+echo "export EXPORTTEST=\" hello\"" | bash
+echo $?
+echo "export EXPORTTEST=\" hello\" ; export > bash_export" | bash
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+
 printf "${YELLOW}%s${RESET}\n" "[mini] export EXPORTTEST= 0123"
 ./export.out export EXPORTTEST= 0123 > mini_export
 echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] export EXPORTTEST= 0123"
 echo "export EXPORTTEST= 0123" | bash
 echo $?
-echo "export EXPORTTEST= 0123 ; export > bash_export" | bash
+echo "export EXPORTTEST= 0123 2> /dev/null ; export 1> bash_export" | bash
 echo "===diff check start==="
 diff mini_export bash_export
 echo "===diff check end==="
@@ -286,7 +299,7 @@ echo
 printf "${YELLOW}%s${RESET}\n" "[mini] export EXP0RT0TEST=0123"
 ./export.out export EXPORT0TEST=0123 > mini_export
 echo $?
-printf "${YELLOW}%s${RESET}\n" "[bash] export 0EXPORT0TEST=0123"
+printf "${YELLOW}%s${RESET}\n" "[bash] export EXPORT0TEST=0123"
 echo "export EXPORT0TEST=0123" | bash
 echo $?
 echo "export EXPORT0TEST=0123 ; export> bash_export" | bash
@@ -294,7 +307,6 @@ echo "===diff check start==="
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
-echo
 echo
 
 # 最後に数字
@@ -387,6 +399,62 @@ printf "${YELLOW}%s${RESET}\n" "[bash] export EXPORTTEST=\"echo \"\$USER\"\""
 echo "export EXPORTTEST=\"echo \"\$USER\"\"" | bash
 echo $?
 echo "export EXPORTTEST=\"echo \"\$USER\"\" ; export > bash_export" | bash
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+
+# += new
+printf "${YELLOW}%s${RESET}\n" "[mini] export EXPORTTEST+=012"
+./export.out export EXPORTTEST+=012 > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export EXPORTTEST+=012"
+echo "export EXPORTTEST+=012" | bash
+echo $?
+echo "export EXPORTTEST+=012 ; export > bash_export" | bash
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+
+# = new, += join
+printf "${YELLOW}%s${RESET}\n" "[mini] export EXPORTTEST=012 EXPORTTEST+=34"
+./export.out export EXPORTTEST=012 EXPORTTEST+=34 > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export EXPORTTEST=012 EXPORTTEST+=34"
+echo "export EXPORTTEST=012 EXPORTTEST+=34" | bash
+echo $?
+echo "export EXPORTTEST=012 ; export > bash_export; EXPORTTEST+=34 ; export >> bash_export" | bash
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+
+#  += new, += join, += join
+printf "${YELLOW}%s${RESET}\n" "[mini] export EXPORTTEST+=012 EXPORTTEST+=34 EXPORTTEST+=abc"
+./export.out export EXPORTTEST+=012 EXPORTTEST+=34 EXPORTTEST+=abc > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export EXPORTTEST+=012 EXPORTTEST+=34 EXPORTTEST+=abc"
+echo "export EXPORTTEST+=012 EXPORTTEST+=34 EXPORTTEST+=abc" | bash
+echo $?
+echo "export EXPORTTEST+=012 ; export > bash_export; EXPORTTEST+=34 ; export >> bash_export ; EXPORTTEST+=abc ; export >> bash_export" | bash
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+
+# += new (no value)
+printf "${YELLOW}%s${RESET}\n" "[mini] export EXPORTTEST+="
+./export.out export EXPORTTEST+= > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export EXPORTTEST+="
+echo "export EXPORTTEST+=" | bash
+echo $?
+echo "export EXPORTTEST+= ; export > bash_export" | bash
 echo "===diff check start==="
 diff mini_export bash_export
 echo "===diff check end==="

--- a/exporttest.sh
+++ b/exporttest.sh
@@ -355,3 +355,40 @@ diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
 echo
+
+# 既存の環境変数をnameのみで上書きしようとする -> 何もしない
+printf "${YELLOW}%s${RESET}\n" "[mini] export HOME"
+./export.out export HOME
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export HOME"
+echo "export HOME" | bash
+echo $?
+echo
+
+# 既存の環境変数をnameのみで上書きしようとする -> 何もしない & 正常ケース
+printf "${YELLOW}%s${RESET}\n" "[mini] export HOME EXPORTTEST=0123"
+./export.out export HOME EXPORTTEST=0123 > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export HOME EXPORTTEST=0123"
+echo "export HOME EXPORTTEST=0123" | bash
+echo $?
+echo "export HOME EXPORTTEST=0123 ; export > bash_export" | bash
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+
+# 複数ダブルクォート
+printf "${YELLOW}%s${RESET}\n" "[mini] export EXPORTTEST=\"echo \"\$USER\"\""
+./export.out export EXPORTTEST="echo "$USER"" > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export EXPORTTEST=\"echo \"\$USER\"\""
+echo "export EXPORTTEST=\"echo \"\$USER\"\"" | bash
+echo $?
+echo "export EXPORTTEST=\"echo \"\$USER\"\" ; export > bash_export" | bash
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo

--- a/includes/minishell_sikeda.h
+++ b/includes/minishell_sikeda.h
@@ -53,7 +53,7 @@ t_list	*g_env;
 char	*ft_getenv(const char *name);
 int		ft_unsetenv(const char *name);
 int		ft_setenv(char *str);
-int		ft_setenv_sep(char *name, char *value);
+int		ft_setenv_sep(const char *name, const char *value);
 int		ft_unsetenv(const char *name);
 void	ft_envsort(t_list **lst);
 void	ft_clear_copied_env(t_list **cpy);

--- a/srcs/env_utils.c
+++ b/srcs/env_utils.c
@@ -64,7 +64,7 @@ int
 }
 
 int
-	ft_setenv_sep(char *name, char *value)
+	ft_setenv_sep(const char *name, const char *value)
 {
 	char	*equal_value;
 	char	*env_str;


### PR DESCRIPTION
# 概要
issue #95 export関数で既存の環境変数を「export name」のようにvalueなしで上書きしようとした際、上書きしない
issue #96 export関数に+=による環境変数の追加/value変更機能を実装

# 受入条件
内容確認、動作確認（exporttest.sh）

# コメント
- exporttest.shに既存の環境変数をnameのみで上書きするテストケースを追加しました
- exporttest.shに+=用のテストケースを追加しました
- exporttest.shに複数ダブルクォート（EXPORTTEST="echo "$USER""）のテストケースを追加しました
  - このケースもechotest.sh等と同じように、bashがトークン展開してからexporttest.shに値を渡すので、ft_exportでは特に何もすることなくうまくいきます

close #95
close #96