### PR TITLE
update #105 to keep the value of g_pwd correctly when cd function after current directory is deleted

### DIFF
--- a/cdtest.sh
+++ b/cdtest.sh
@@ -318,3 +318,22 @@ printf "OLDPWD: ${OLDPWD}\n"
 cd $WORKDIR
 export HOME=$HOMEDIR
 echo
+
+# mkdir cdtest; cd cdtest ; rmdir ../cdtest ; cd "" ;
+printf "${CYAN}%s${RESET}\n" "pwd:
+${WORKDIR}"
+printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest ; rmdir ../cdtest ; cd \"\" ; pwd"
+${WORKDIR}/cd.out cd_nodir
+echo $?
+cd $WORKDIR
+printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest ; rmdir ../cdtest ; cd \"\" ; pwd"
+#終了ステータスを取るためのコマンド、出力を消して実行
+mkdir cdtest ; cd cdtest ; rmdir ../cdtest ; cd "" 2> /dev/null ; pwd &> /dev/null
+echo $?
+cd $WORKDIR
+#画面表示用のコマンド
+mkdir cdtest ; cd cdtest ; rmdir ../cdtest ; cd "" ; pwd
+printf "PWD: ${PWD}\n"
+printf "OLDPWD: ${OLDPWD}\n"
+cd $WORKDIR
+echo

--- a/srcs/cd.c
+++ b/srcs/cd.c
@@ -1,13 +1,38 @@
 #include "minishell_sikeda.h"
 
+#ifdef CDTEST
+int
+	lsh_launch(char **args)
+{
+	pid_t	pid;
+	pid_t	wpid;
+	int		status;
+
+	if ((pid = fork()) < 0)
+		perror("lsh");
+	if (pid == 0)
+	{
+		if (execvp(args[0], args) == -1)
+			perror("lsh");
+		exit(EXIT_FAILURE);
+	} else {
+		do
+		{
+			wpid = waitpid(pid, &status, WUNTRACED);
+		} while (!WIFEXITED(status) && !WIFSIGNALED(status));
+	}
+	return (1);
+}
+#endif
+
 static t_bool
-	validate_args(char **args)
+	validate_args(const char *args)
 {
 	t_bool	ret;
 	char	option[3];
 
 	ret = TRUE;
-	if (ft_get_cmd_option(option, *args))
+	if (ft_get_cmd_option(option, args))
 	{
 		ft_put_cmderror_with_arg("cd", CMD_OPTION_ERR, option);
 		ft_put_cmderror_with_help("cd", CMD_CD_HELP);
@@ -17,25 +42,24 @@ static t_bool
 }
 
 static char
-	*get_path(char **args)
+	*get_path(const char *args)
 {
 	char	*path;
 
-	if (!*args)
+	if (!args)
 	{
 		if (!(path = ft_getenv("HOME")))
 		{
 			ft_put_cmderror("cd", "HOME not set");
 			return (NULL);
 		}
+		return (path);
 	}
-	else
-		path = *args;
-	return (path);
+	return ((char*)args);
 }
 
 static t_bool
-	exec_cd(char *path)
+	exec_cd(char *path, char *args)
 {
 	t_bool	ret;
 
@@ -43,14 +67,14 @@ static t_bool
 	if (!path)
 		return (ret);
 	if (chdir(path) != 0)
-		ft_put_cmderror_with_arg("cd", strerror(errno), path);
+		ft_put_cmderror_with_arg("cd", strerror(errno), args);
 	else
 		ret = TRUE;
 	return (ret);
 }
 
 static t_bool
-	update_path_env()
+	update_path_env(void)
 {
 	if (ft_getenv("OLDPWD") && ft_setenv_sep("OLDPWD", g_pwd) == UTIL_ERROR)
 	{
@@ -70,36 +94,24 @@ static t_bool
 int
 	ft_cd(char **args)
 {
+	char	*path;
+
 	g_status = STATUS_GENERAL_ERR;
 	args++;
 	if (*args && !ft_strcmp(*args, "--"))
 		args++;
-	if (validate_args(args) == FALSE)
+	if (validate_args(*args) == FALSE)
 		return (KEEP_RUNNING);
 	if (*args && **args == '\0')
+		path = g_pwd;
+	else
+		path = *args;
+	if (exec_cd(get_path(path), *args) == TRUE)
 	{
 		if (update_path_env() == FALSE)
 			return (STOP);
 		g_status = STATUS_SUCCESS;
 	}
-	else
-	{
-		if (exec_cd(get_path(args)) == TRUE)
-		{
-			if (update_path_env() == FALSE)
-				return (STOP);
-			g_status = STATUS_SUCCESS;
-		}
-	}
-#ifdef CDTEST
-	if (g_status == STATUS_SUCCESS)
-	{
-		char	*pwdargs[] = {"pwd", NULL};
-		ft_pwd(pwdargs);
-		printf("PWD: %s\n", ft_getenv("PWD"));
-		printf("OLDPWD: %s\n", ft_getenv("OLDPWD"));
-	}
-#endif
 	return (KEEP_RUNNING);
 }
 
@@ -137,7 +149,32 @@ int
 	args_head = args;
 	ret = 0;
 	if (!ft_strcmp(args[1], "cd"))
+	{
 		ret = ft_cd(++args);
+		if (g_status == STATUS_SUCCESS)
+		{
+			char	*pwdargs[] = {"pwd", NULL};
+			ft_pwd(pwdargs);
+			printf("PWD: %s\n", ft_getenv("PWD"));
+			printf("OLDPWD: %s\n", ft_getenv("OLDPWD"));
+		}
+	}
+	else if (!ft_strcmp(args[1], "cd_nodir"))
+	{
+		char		*args1[] = {"mkdir", "cdtest", NULL};
+		lsh_launch(args1);
+		fflush(stdout);
+		char		*args2[] = {"cd", "cdtest", NULL};
+		ret = ft_cd(args2);
+		char		*args3[] = {"rmdir", "../cdtest", NULL};
+		lsh_launch(args3);
+		char		*args4[] = {"cd", "", NULL};
+		ret = ft_cd(args4);
+		char	*pwdargs[] = {"pwd", NULL};
+		ft_pwd(pwdargs);
+		printf("PWD: %s\n", ft_getenv("PWD"));
+		printf("OLDPWD: %s\n", ft_getenv("OLDPWD"));
+	}
 	else if (!ft_strcmp(args[1], "pwd"))
 		ret = ft_pwd(++args);
 	else if (!ft_strcmp(args[1], "env"))


### PR DESCRIPTION
# 概要
issue #105 カレントディレクトリが削除されたあとcd ""; pwd; したときの値表示

# 受入条件
内容確認、動作確認（cdtest.sh）

# コメント
issue #105 に書いたシナリオの際にpwdが正しく表示されるようにしました。
具体的には、`cd ""`のケースは無条件にg_pwd、PWD、OLDPWDの書き換えをしていましたが、このシナリオでは`cd ""`は失敗するので、無条件に書き換えないようにしました。

複雑な内容を再現するため、「./cd.out cd_nodir」と実行すると上記シナリオが実行されるようにしました。（cdtest.shの１番最後にもテストケースで追加してあります）

close #105