### PR TITLE
Feature/make current path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,72 @@
+NAME		:= minishell
+
+UTILDIR		:= ./srcs/utils/
+
+SRCS		:=
+SRCS		+= srcs/cd.c srcs/cd_path_utils.c srcs/cd_fullpath.c \
+				srcs/echo.c srcs/pwd.c srcs/exit.c \
+				srcs/env.c srcs/unset.c \
+				srcs/export.c srcs/export_print.c srcs/export_setenv.c \
+				srcs/init_env.c srcs/env_utils.c srcs/env_utils2.c \
+				srcs/env_sort.c srcs/env_copy.c \
+				$(UTILDIR)command_utils.c $(UTILDIR)command_errors.c $(UTILDIR)minishell_errors.c \
+				$(UTILDIR)tlist_utils.c $(UTILDIR)split_utils.c $(UTILDIR)utils.c
+OBJS		= $(SRCS:.c=.o)
+
+SRCS_BUITINTEST	:= $(SRCS)
+SRCS_BUITINTEST	+= test/test_builtin.c test/test_init.c test/test_exec.c test/test_launch.c
+OBJS_BUITINTEST	= $(SRCS_BUITINTEST:.c=.o)
+
+INCLUDE		:= -I./includes/ -I./libft/ -I./test/
+
+LIBDIR		:= ./libft
+LIBPATH		:= $(LIBDIR)/libft.a
+
+CC			:= gcc
+CFLAGS		:= -Wall -Wextra -Werror
+# DEBUG		:= -g -fsanitize=address
+DEBUG		:=
+
+RM			:= rm -f
+C_GREEN		:= "\x1b[32m"
+
+.c.o:
+			$(CC) $(CFLAGS) $(DEBUG) $(INCLUDE) -c $< -o $@
+
+all:		$(NAME)
+
+$(NAME):	$(OBJS) $(LIBPATH)
+			$(CC) $(CFLAGS) $(OBJ) $(DEBUG) $(LIBPATH) -o $(NAME)
+			@echo $(C_GREEN)"=== Make Done ==="
+
+btest:		$(LIBPATH)
+			$(CC) $(CFLAGS) $(SRCS_BUITINTEST) $(DEBUG) $(INCLUDE) $(LIBPATH) -D TEST -o builtin.out
+			@echo $(C_GREEN)"=== Make Done ==="
+
+bltest:		$(LIBPATH)
+			$(CC) $(CFLAGS) $(SRCS_BUITINTEST) $(DEBUG) $(INCLUDE) $(LIBPATH) -D CDTEST -D LEAKS -o builtin.out
+			@echo $(C_GREEN)"=== Make Done ==="
+
+cdtest:		$(LIBPATH)
+			$(CC) $(CFLAGS) $(SRCS_BUITINTEST) $(DEBUG) $(INCLUDE) $(LIBPATH) -D CDTEST -o builtin.out
+			@echo $(C_GREEN)"=== Make Done ==="
+
+cdltest:	$(LIBPATH)
+			$(CC) $(CFLAGS) $(SRCS_BUITINTEST) $(DEBUG) $(INCLUDE) $(LIBPATH) -D CDTEST -D LEAKS -o builtin.out
+			@echo $(C_GREEN)"=== Make Done ==="
+
+$(LIBPATH):
+			$(MAKE) bonus -C $(LIBDIR)
+
+clean:
+			$(RM) $(OBJS)
+			$(RM) $(OBJS_BUITINTEST)
+			$(MAKE) clean -C $(LIBDIR)
+
+fclean:		clean
+			$(RM) $(NAME)
+			$(MAKE) fclean -C $(LIBDIR)
+
+re:			fclean $(NAME)
+
+.PHONY:		all clean fclean re btest bltest cdtest cdltest

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ NAME		:= minishell
 UTILDIR		:= ./srcs/utils/
 
 SRCS		:=
-SRCS		+= srcs/cd.c srcs/cd_path_utils.c srcs/cd_fullpath.c \
+SRCS		+= srcs/cd.c srcs/cd_error.c srcs/cd_path_utils.c srcs/cd_fullpath.c \
 				srcs/echo.c srcs/pwd.c srcs/exit.c \
 				srcs/env.c srcs/unset.c \
 				srcs/export.c srcs/export_print.c srcs/export_setenv.c \
@@ -14,7 +14,7 @@ SRCS		+= srcs/cd.c srcs/cd_path_utils.c srcs/cd_fullpath.c \
 OBJS		= $(SRCS:.c=.o)
 
 SRCS_BUITINTEST	:= $(SRCS)
-SRCS_BUITINTEST	+= test/test_builtin.c test/test_init.c test/test_exec.c test/test_launch.c
+SRCS_BUITINTEST	+= test/test_builtin.c test/test_init.c test/test_exec.c test/test_launch.c test/test_cd.c
 OBJS_BUITINTEST	= $(SRCS_BUITINTEST:.c=.o)
 
 INCLUDE		:= -I./includes/ -I./libft/ -I./test/

--- a/cdtest.sh
+++ b/cdtest.sh
@@ -588,7 +588,7 @@ printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest; rmdir ../cdtest;
 ${WORKDIR}/builtin.out cd_nodir ""
 echo $?
 cd $WORKDIR
-printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest; rmdir ../cdtest; cd \"\"; pwd"
+printf "${YELLOW}%s${RESET}\n" "[bash] mkdir cdtest; cd cdtest; rmdir ../cdtest; cd \"\"; pwd"
 #終了ステータスを取るためのコマンド、出力を消して実行
 mkdir cdtest; cd cdtest; rmdir ../cdtest; cd "" 2> /dev/null; pwd &> /dev/null
 echo $?
@@ -607,7 +607,7 @@ printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest; rmdir ../cdtest;
 ${WORKDIR}/builtin.out cd_nodir .
 echo $?
 cd $WORKDIR
-printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest; rmdir ../cdtest; cd .; pwd"
+printf "${YELLOW}%s${RESET}\n" "[bash] mkdir cdtest; cd cdtest; rmdir ../cdtest; cd .; pwd"
 #終了ステータスを取るためのコマンド、出力を消して実行
 mkdir cdtest; cd cdtest; rmdir ../cdtest; cd . 2> /dev/null; pwd &> /dev/null
 echo $?
@@ -626,7 +626,7 @@ printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest; rmdir ../cdtest;
 ${WORKDIR}/builtin.out cd_nodir .//.//
 echo $?
 cd $WORKDIR
-printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest; rmdir ../cdtest; cd .//.//; pwd"
+printf "${YELLOW}%s${RESET}\n" "[bash] mkdir cdtest; cd cdtest; rmdir ../cdtest; cd .//.//; pwd"
 #終了ステータスを取るためのコマンド、出力を消して実行
 mkdir cdtest; cd cdtest; rmdir ../cdtest; cd .//.// 2> /dev/null; pwd &> /dev/null
 echo $?
@@ -645,7 +645,7 @@ printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest; rmdir ../cdtest;
 ${WORKDIR}/builtin.out cd_nodir2 .
 echo $?
 cd $WORKDIR
-printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest; rmdir ../cdtest; cd .; pwd; cd ..; pwd"
+printf "${YELLOW}%s${RESET}\n" "[bash] mkdir cdtest; cd cdtest; rmdir ../cdtest; cd .; pwd; cd ..; pwd"
 #終了ステータスを取るためのコマンド、出力を消して実行
 mkdir cdtest; cd cdtest; rmdir ../cdtest; cd . 2> /dev/null; cd ..; pwd &> /dev/null
 echo $?
@@ -667,7 +667,7 @@ printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest; rmdir ../cdtest;
 ${WORKDIR}/builtin.out cd_nodir2 ./././.
 echo $?
 cd $WORKDIR
-printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest; rmdir ../cdtest; cd ./././.; pwd; cd ..; pwd"
+printf "${YELLOW}%s${RESET}\n" "[bash] mkdir cdtest; cd cdtest; rmdir ../cdtest; cd ./././.; pwd; cd ..; pwd"
 #終了ステータスを取るためのコマンド、出力を消して実行
 mkdir cdtest; cd cdtest; rmdir ../cdtest; cd ./././. 2> /dev/null; cd ..; pwd &> /dev/null
 echo $?

--- a/cdtest.sh
+++ b/cdtest.sh
@@ -1,7 +1,27 @@
 #!/bin/bash
 
-make cdtest
-# make cdltest # LEAK TEST
+# USAGE ##################
+#
+# all test
+# ./cdtest.sh
+#
+# all test with leaks
+# ./cdtest.sh leaks
+#
+# make only
+# ./cdtest.sh make
+#
+##########################
+
+if [ $1 = "leaks" ]; then
+    make cdltest # LEAK TEST
+else
+    make cdtest
+fi
+
+if [ $1 = "make" ]; then
+    exit
+fi
 
 YELLOW=$(printf '\033[33m')
 CYAN=$(printf '\033[36m')
@@ -561,40 +581,102 @@ cd $WORKDIR
 export HOME=$HOMEDIR
 echo
 
-# mkdir cdtest; cd cdtest ; rmdir ../cdtest ; cd "" ;
+# mkdir cdtest; cd cdtest; rmdir ../cdtest; cd "";
 printf "${CYAN}%s${RESET}\n" "pwd:
 ${WORKDIR}"
-printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest ; rmdir ../cdtest ; cd \"\" ; pwd"
+printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest; rmdir ../cdtest; cd \"\"; pwd"
 ${WORKDIR}/builtin.out cd_nodir ""
 echo $?
 cd $WORKDIR
-printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest ; rmdir ../cdtest ; cd \"\" ; pwd"
+printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest; rmdir ../cdtest; cd \"\"; pwd"
 #終了ステータスを取るためのコマンド、出力を消して実行
-mkdir cdtest ; cd cdtest ; rmdir ../cdtest ; cd "" 2> /dev/null ; pwd &> /dev/null
+mkdir cdtest; cd cdtest; rmdir ../cdtest; cd "" 2> /dev/null; pwd &> /dev/null
 echo $?
 cd $WORKDIR
 #画面表示用のコマンド
-mkdir cdtest ; cd cdtest ; rmdir ../cdtest ; cd "" ; pwd
+mkdir cdtest; cd cdtest; rmdir ../cdtest; cd ""; pwd
 printf "PWD: ${PWD}\n"
 printf "OLDPWD: ${OLDPWD}\n"
 cd $WORKDIR
 echo
 
-# issue#107 カレントディレクトリが削除されたあとcd . ; pwd;で対応する
-# mkdir cdtest; cd cdtest ; rmdir ../cdtest ; cd . ;
+# mkdir cdtest; cd cdtest; rmdir ../cdtest; cd .;
 printf "${CYAN}%s${RESET}\n" "pwd:
 ${WORKDIR}"
-printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest ; rmdir ../cdtest ; cd . ; pwd"
+printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest; rmdir ../cdtest; cd .; pwd"
 ${WORKDIR}/builtin.out cd_nodir .
 echo $?
 cd $WORKDIR
-printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest ; rmdir ../cdtest ; cd . ; pwd"
+printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest; rmdir ../cdtest; cd .; pwd"
 #終了ステータスを取るためのコマンド、出力を消して実行
-mkdir cdtest ; cd cdtest ; rmdir ../cdtest ; cd . 2> /dev/null ; pwd &> /dev/null
+mkdir cdtest; cd cdtest; rmdir ../cdtest; cd . 2> /dev/null; pwd &> /dev/null
 echo $?
 cd $WORKDIR
 #画面表示用のコマンド
-mkdir cdtest ; cd cdtest ; rmdir ../cdtest ; cd . ; pwd
+mkdir cdtest; cd cdtest; rmdir ../cdtest; cd .; pwd
+printf "PWD: ${PWD}\n"
+printf "OLDPWD: ${OLDPWD}\n"
+cd $WORKDIR
+echo
+
+# mkdir cdtest; cd cdtest; rmdir ../cdtest; cd .//.//;
+printf "${CYAN}%s${RESET}\n" "pwd:
+${WORKDIR}"
+printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest; rmdir ../cdtest; cd .//.//; pwd"
+${WORKDIR}/builtin.out cd_nodir .//.//
+echo $?
+cd $WORKDIR
+printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest; rmdir ../cdtest; cd .//.//; pwd"
+#終了ステータスを取るためのコマンド、出力を消して実行
+mkdir cdtest; cd cdtest; rmdir ../cdtest; cd .//.// 2> /dev/null; pwd &> /dev/null
+echo $?
+cd $WORKDIR
+#画面表示用のコマンド
+mkdir cdtest; cd cdtest; rmdir ../cdtest; cd .//.//; pwd
+printf "PWD: ${PWD}\n"
+printf "OLDPWD: ${OLDPWD}\n"
+cd $WORKDIR
+echo
+
+# mkdir cdtest; cd cdtest; rmdir ../cdtest; cd .; cd ..; pwd;
+printf "${CYAN}%s${RESET}\n" "pwd:
+${WORKDIR}"
+printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest; rmdir ../cdtest; cd .; pwd; cd ..; pwd"
+${WORKDIR}/builtin.out cd_nodir2 .
+echo $?
+cd $WORKDIR
+printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest; rmdir ../cdtest; cd .; pwd; cd ..; pwd"
+#終了ステータスを取るためのコマンド、出力を消して実行
+mkdir cdtest; cd cdtest; rmdir ../cdtest; cd . 2> /dev/null; cd ..; pwd &> /dev/null
+echo $?
+cd $WORKDIR
+#画面表示用のコマンド
+mkdir cdtest; cd cdtest; rmdir ../cdtest; cd .; pwd;
+printf "PWD: ${PWD}\n"
+printf "OLDPWD: ${OLDPWD}\n"
+cd ..; pwd
+printf "PWD: ${PWD}\n"
+printf "OLDPWD: ${OLDPWD}\n"
+cd $WORKDIR
+echo
+
+# mkdir cdtest; cd cdtest; rmdir ../cdtest; cd .; cd ..; pwd;
+printf "${CYAN}%s${RESET}\n" "pwd:
+${WORKDIR}"
+printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest; rmdir ../cdtest; cd ./././.; pwd; cd ..; pwd"
+${WORKDIR}/builtin.out cd_nodir2 ./././.
+echo $?
+cd $WORKDIR
+printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest; rmdir ../cdtest; cd ./././.; pwd; cd ..; pwd"
+#終了ステータスを取るためのコマンド、出力を消して実行
+mkdir cdtest; cd cdtest; rmdir ../cdtest; cd ./././. 2> /dev/null; cd ..; pwd &> /dev/null
+echo $?
+cd $WORKDIR
+#画面表示用のコマンド
+mkdir cdtest; cd cdtest; rmdir ../cdtest; cd ./././.; pwd;
+printf "PWD: ${PWD}\n"
+printf "OLDPWD: ${OLDPWD}\n"
+cd ..; pwd
 printf "PWD: ${PWD}\n"
 printf "OLDPWD: ${OLDPWD}\n"
 cd $WORKDIR

--- a/cdtest.sh
+++ b/cdtest.sh
@@ -1,15 +1,7 @@
 #!/bin/bash
 
-cd libft
-make bonus
-cd ..
-gcc -g -Wall -Wextra -Werror -I./includes -I./libft -I./test \
-    test/test_builtin.c test/test_init.c test/test_exec.c test/test_launch.c \
-    srcs/echo.c srcs/cd.c srcs/pwd.c srcs/exit.c srcs/env.c srcs/unset.c \
-    srcs/export.c srcs/export_print.c srcs/export_setenv.c \
-    srcs/init_env.c srcs/env_utils.c srcs/env_utils2.c srcs/env_sort.c srcs/env_copy.c \
-    srcs/utils/utils.c srcs/utils/minishell_errors.c srcs/utils/command_utils.c srcs/utils/command_errors.c \
-    -Llibft -lft -D CDTEST -o builtin.out #-D LEAKS
+make cdtest
+# make cdltest # LEAK TEST
 
 YELLOW=$(printf '\033[33m')
 CYAN=$(printf '\033[36m')
@@ -57,6 +49,36 @@ echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] cd \"~\""
 cd "~"
 echo $?
+cd $WORKDIR
+echo
+
+# cd .
+printf "${CYAN}%s${RESET}\n" "pwd:
+${WORKDIR}"
+printf "${YELLOW}%s${RESET}\n" "[mini] cd ."
+./builtin.out cd .
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] cd ."
+cd .
+echo $?
+pwd
+printf "PWD: ${PWD}\n"
+printf "OLDPWD: ${OLDPWD}\n"
+cd $WORKDIR
+echo
+
+# cd ..
+printf "${CYAN}%s${RESET}\n" "pwd:
+${WORKDIR}"
+printf "${YELLOW}%s${RESET}\n" "[mini] cd .."
+./builtin.out cd ..
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] cd .."
+cd ..
+echo $?
+pwd
+printf "PWD: ${PWD}\n"
+printf "OLDPWD: ${OLDPWD}\n"
 cd $WORKDIR
 echo
 
@@ -135,6 +157,220 @@ cd $WORKDIR
 rm -rf cdtest
 echo
 
+# cd CDtest
+printf "${CYAN}%s${RESET}\n" "pwd:
+${WORKDIR}"
+printf "${YELLOW}%s${RESET}\n" "mkdir cdtest"
+mkdir cdtest
+printf "${YELLOW}%s${RESET}\n" "[mini] cd CDtest"
+./builtin.out cd CDtest
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] cd CDtest"
+cd CDtest
+echo $?
+pwd
+printf "PWD: ${PWD}\n"
+printf "OLDPWD: ${OLDPWD}\n"
+cd $WORKDIR
+rm -rf cdtest
+echo
+
+# cd /..
+printf "${CYAN}%s${RESET}\n" "pwd:
+${WORKDIR}"
+printf "${YELLOW}%s${RESET}\n" "[mini] cd /.."
+./builtin.out cd /..
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] cd /.."
+cd /..
+echo $?
+pwd
+printf "PWD: ${PWD}\n"
+printf "OLDPWD: ${OLDPWD}\n"
+cd $WORKDIR
+rm -rf cdtest
+echo
+
+# cd /./../
+printf "${CYAN}%s${RESET}\n" "pwd:
+${WORKDIR}"
+printf "${YELLOW}%s${RESET}\n" "[mini] cd /./../"
+./builtin.out cd /./../
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] cd /./../"
+cd /./../
+echo $?
+pwd
+printf "PWD: ${PWD}\n"
+printf "OLDPWD: ${OLDPWD}\n"
+cd $WORKDIR
+rm -rf cdtest
+echo
+
+# cd ./CDtest
+printf "${CYAN}%s${RESET}\n" "pwd:
+${WORKDIR}"
+printf "${YELLOW}%s${RESET}\n" "mkdir cdtest"
+mkdir cdtest
+printf "${YELLOW}%s${RESET}\n" "[mini] cd ./CDtest"
+./builtin.out cd ./CDtest
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] cd ./CDtest"
+cd ./CDtest
+echo $?
+pwd
+printf "PWD: ${PWD}\n"
+printf "OLDPWD: ${OLDPWD}\n"
+cd $WORKDIR
+rm -rf cdtest
+echo
+
+# cd cdtest; cd ../CDTEST
+printf "${CYAN}%s${RESET}\n" "pwd:
+${WORKDIR}"
+printf "${YELLOW}%s${RESET}\n" "mkdir cdtest ; cd cdtest"
+mkdir cdtest ; cd cdtest
+printf "${YELLOW}%s${RESET}\n" "[mini] cd ../CDTEST"
+${WORKDIR}/builtin.out cd ../CDTEST
+echo $?
+cd $WORKDIR
+rm -rf cdtest
+printf "${YELLOW}%s${RESET}\n" "mkdir cdtest ; cd cdtest"
+mkdir cdtest ; cd cdtest
+printf "${YELLOW}%s${RESET}\n" "[bash] cd ../CDTEST"
+cd ../CDTEST
+echo $?
+pwd
+printf "PWD: ${PWD}\n"
+printf "OLDPWD: ${OLDPWD}\n"
+cd $WORKDIR
+rm -rf cdtest
+echo
+
+# cd test1; cd .../TEST1/TEST2/TEST3/..
+printf "${CYAN}%s${RESET}\n" "pwd:
+${WORKDIR}"
+printf "${YELLOW}%s${RESET}\n" "mkdir -p test1/test2/test3 ; cd test1"
+mkdir -p test1/test2/test3 ; cd test1
+printf "${YELLOW}%s${RESET}\n" "[mini] cd ../TEST1/TEST2/TEST3/.."
+${WORKDIR}/builtin.out cd ../TEST1/TEST2/TEST3/..
+echo $?
+cd $WORKDIR
+rmdir -p test1/test2/test3
+printf "${YELLOW}%s${RESET}\n" "mkdir -p test1/test2/test3 ; cd test1"
+mkdir -p test1/test2/test3 ; cd test1
+printf "${YELLOW}%s${RESET}\n" "[bash] cd ../TEST1/TEST2/TEST3/.."
+cd ../TEST1/TEST2/TEST3/..
+echo $?
+pwd
+printf "PWD: ${PWD}\n"
+printf "OLDPWD: ${OLDPWD}\n"
+cd $WORKDIR
+rmdir -p test1/test2/test3
+echo
+
+# cd test1; cd ../../../TEST1
+printf "${CYAN}%s${RESET}\n" "pwd:
+${WORKDIR}"
+printf "${YELLOW}%s${RESET}\n" "mkdir -p test1/test2/test3 ; cd test1/test2/test3"
+mkdir -p test1/test2/test3 ; cd test1/test2/test3
+printf "${YELLOW}%s${RESET}\n" "[mini] cd ../../../TEST1"
+${WORKDIR}/builtin.out cd ../../../TEST1
+echo $?
+cd $WORKDIR
+rmdir -p test1/test2/test3
+printf "${YELLOW}%s${RESET}\n" "mkdir -p test1/test2/test3 ; cd test1/test2/test3"
+mkdir -p test1/test2/test3 ; cd test1/test2/test3
+printf "${YELLOW}%s${RESET}\n" "[bash] cd ../../../TEST1"
+cd ../../../TEST1
+echo $?
+pwd
+printf "PWD: ${PWD}\n"
+printf "OLDPWD: ${OLDPWD}\n"
+cd $WORKDIR
+rmdir -p test1/test2/test3
+echo
+
+# cd / ; cd ""
+printf "${CYAN}%s${RESET}\n" "pwd:
+${WORKDIR}"
+printf "${YELLOW}%s${RESET}\n" "cd /"
+cd /
+printf "${YELLOW}%s${RESET}\n" "[mini] cd \"\""
+${WORKDIR}/builtin.out cd ""
+echo $?
+cd $WORKDIR
+printf "${YELLOW}%s${RESET}\n" "cd /"
+cd /
+printf "${YELLOW}%s${RESET}\n" "[bash] cd \"\""
+cd /
+echo $?
+pwd
+printf "PWD: ${PWD}\n"
+printf "OLDPWD: ${OLDPWD}\n"
+cd $WORKDIR
+echo
+
+# cd / ; cd .
+printf "${CYAN}%s${RESET}\n" "pwd:
+${WORKDIR}"
+printf "${YELLOW}%s${RESET}\n" "cd /"
+cd /
+printf "${YELLOW}%s${RESET}\n" "[mini] cd ."
+${WORKDIR}/builtin.out cd .
+echo $?
+cd $WORKDIR
+printf "${YELLOW}%s${RESET}\n" "cd /"
+cd /
+printf "${YELLOW}%s${RESET}\n" "[bash] cd ."
+cd .
+echo $?
+pwd
+printf "PWD: ${PWD}\n"
+printf "OLDPWD: ${OLDPWD}\n"
+cd $WORKDIR
+echo
+
+# cd / ; cd /
+printf "${CYAN}%s${RESET}\n" "pwd:
+${WORKDIR}"
+printf "${YELLOW}%s${RESET}\n" "cd /"
+cd /
+printf "${YELLOW}%s${RESET}\n" "[mini] cd /"
+${WORKDIR}/builtin.out cd /
+echo $?
+cd $WORKDIR
+printf "${YELLOW}%s${RESET}\n" "cd /"
+cd /
+printf "${YELLOW}%s${RESET}\n" "[bash] cd /"
+cd /
+echo $?
+pwd
+printf "PWD: ${PWD}\n"
+printf "OLDPWD: ${OLDPWD}\n"
+cd $WORKDIR
+echo
+
+# cd / ; cd
+printf "${CYAN}%s${RESET}\n" "pwd:
+${WORKDIR}"
+printf "${YELLOW}%s${RESET}\n" "cd /"
+cd /
+printf "${YELLOW}%s${RESET}\n" "[mini] cd"
+${WORKDIR}/builtin.out cd
+echo $?
+cd $WORKDIR
+printf "${YELLOW}%s${RESET}\n" "cd /"
+cd /
+printf "${YELLOW}%s${RESET}\n" "[bash] cd"
+cd
+echo $?
+pwd
+printf "PWD: ${PWD}\n"
+printf "OLDPWD: ${OLDPWD}\n"
+cd $WORKDIR
+echo
+
 # cd "cdtest"
 printf "${CYAN}%s${RESET}\n" "pwd:
 ${WORKDIR}"
@@ -168,7 +404,7 @@ cd $WORKDIR
 rm -rf cdtest
 echo
 
-# cd "cdtest"
+# cd cdtest hoge
 printf "${CYAN}%s${RESET}\n" "pwd:
 ${WORKDIR}"
 printf "${YELLOW}%s${RESET}\n" "mkdir cdtest"
@@ -329,7 +565,7 @@ echo
 printf "${CYAN}%s${RESET}\n" "pwd:
 ${WORKDIR}"
 printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest ; rmdir ../cdtest ; cd \"\" ; pwd"
-${WORKDIR}/builtin.out cd_nodir
+${WORKDIR}/builtin.out cd_nodir ""
 echo $?
 cd $WORKDIR
 printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest ; rmdir ../cdtest ; cd \"\" ; pwd"
@@ -339,6 +575,26 @@ echo $?
 cd $WORKDIR
 #画面表示用のコマンド
 mkdir cdtest ; cd cdtest ; rmdir ../cdtest ; cd "" ; pwd
+printf "PWD: ${PWD}\n"
+printf "OLDPWD: ${OLDPWD}\n"
+cd $WORKDIR
+echo
+
+# issue#107 カレントディレクトリが削除されたあとcd . ; pwd;で対応する
+# mkdir cdtest; cd cdtest ; rmdir ../cdtest ; cd . ;
+printf "${CYAN}%s${RESET}\n" "pwd:
+${WORKDIR}"
+printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest ; rmdir ../cdtest ; cd . ; pwd"
+${WORKDIR}/builtin.out cd_nodir .
+echo $?
+cd $WORKDIR
+printf "${YELLOW}%s${RESET}\n" "[mini] mkdir cdtest; cd cdtest ; rmdir ../cdtest ; cd . ; pwd"
+#終了ステータスを取るためのコマンド、出力を消して実行
+mkdir cdtest ; cd cdtest ; rmdir ../cdtest ; cd . 2> /dev/null ; pwd &> /dev/null
+echo $?
+cd $WORKDIR
+#画面表示用のコマンド
+mkdir cdtest ; cd cdtest ; rmdir ../cdtest ; cd . ; pwd
 printf "PWD: ${PWD}\n"
 printf "OLDPWD: ${OLDPWD}\n"
 cd $WORKDIR

--- a/includes/minishell_sikeda.h
+++ b/includes/minishell_sikeda.h
@@ -102,8 +102,12 @@ int		ft_echo(char **args);
 /* cd.c */
 int		ft_cd(char **args);
 
-/* cd_utils.c */
+/* cd_error.c */
+void	ft_put_cderror_no_current(const int errornum);
+
+/* cd_path_utils.c */
 char	*ft_join_path(const char *path, const char *new);
+char	*ft_get_home_path(const char *args);
 
 /* cd_fullpath.c */
 char	*ft_make_full_path(const char *input_path);

--- a/includes/minishell_sikeda.h
+++ b/includes/minishell_sikeda.h
@@ -57,6 +57,15 @@ int		ft_isspace(char c);
 int		ft_isnumeric(char *s);
 void	ft_free(char **ptr);
 
+/* utils/split_utils.c */
+void	ft_free_split(char ***split);
+char	*ft_free_split_and_return_str(char ***split, const char *return_value);
+int		ft_free_split_and_return_int(char ***split, const int return_value);
+
+/* utils/tlist_utils.c */
+void	ft_lstdelend(t_list **lst, void (*del)(void*));
+int		ft_lstnew_and_lstadd_back(t_list **path_list, const char *str);
+
 /* utils/command_utils.c */
 int		ft_isover_llrange(char *s);
 char	*ft_get_cmd_option(char *option, const char *arg);
@@ -92,6 +101,12 @@ int		ft_echo(char **args);
 
 /* cd.c */
 int		ft_cd(char **args);
+
+/* cd_utils.c */
+char	*ft_join_path(const char *path, const char *new);
+
+/* cd_fullpath.c */
+char	*ft_make_full_path(const char *input_path);
 
 /* pwd.c */
 int		ft_init_pwd(void);

--- a/srcs/cd.c
+++ b/srcs/cd.c
@@ -16,24 +16,6 @@ static t_bool
 	return (ret);
 }
 
-static char
-	*get_home_path(const char *args)
-{
-	char	*path;
-
-	if (!args)
-	{
-		path = ft_getenv("HOME");
-		if (!path)
-		{
-			ft_put_cmderror("cd", "HOME not set");
-			return (NULL);
-		}
-		return (path);
-	}
-	return ((char *)args);
-}
-
 static t_bool
 	exec_cd(const char *path, const char *args)
 {
@@ -54,19 +36,36 @@ static t_bool
 	return (ret);
 }
 
+static void
+	update_pwd(const char *input_path)
+{
+	char	*oldpwd;
+	char	*cwd;
+
+	oldpwd = g_pwd;
+	cwd = getcwd(NULL, 0);
+	if (cwd)
+	{
+		ft_free(&cwd);
+		g_pwd = ft_make_full_path(input_path);
+	}
+	else
+	{
+		ft_put_cderror_no_current(errno);
+		g_pwd = ft_join_path(g_pwd, input_path);
+	}
+	ft_free(&oldpwd);
+}
+
 static t_bool
 	update_path_env(const char *input_path)
 {
-	char	*oldpwd;
-
 	if (ft_getenv("OLDPWD") && ft_setenv_sep("OLDPWD", g_pwd) == UTIL_ERROR)
 	{
 		ft_put_cmderror("cd", strerror(errno));
 		return (FALSE);
 	}
-	oldpwd = g_pwd;
-	g_pwd = ft_make_full_path(input_path);
-	ft_free(&oldpwd);
+	update_pwd(input_path);
 	if (!g_pwd
 		|| (ft_getenv("PWD") && ft_setenv_sep("PWD", g_pwd) == UTIL_ERROR))
 	{
@@ -91,7 +90,7 @@ int
 		path = g_pwd;
 	else
 		path = *args;
-	path = get_home_path(path);
+	path = ft_get_home_path(path);
 	if (exec_cd(path, *args) == TRUE)
 	{
 		if (update_path_env(path) == FALSE)

--- a/srcs/cd_error.c
+++ b/srcs/cd_error.c
@@ -1,0 +1,13 @@
+#include "minishell_sikeda.h"
+
+void
+	ft_put_cderror_no_current(const int errornum)
+{
+	int	fd;
+
+	fd = STDERR_FILENO;
+	ft_putstr_fd("cd: error retrieving current directory: getcwd: ", fd);
+	ft_putstr_fd("cannot access parent directories: ", fd);
+	ft_putstr_fd(strerror(errornum), fd);
+	ft_putchar_fd('\n', fd);
+}

--- a/srcs/cd_fullpath.c
+++ b/srcs/cd_fullpath.c
@@ -12,8 +12,12 @@ static int
 	*path_list = NULL;
 	i = 0;
 	while (split[i])
-		if (ft_lstnew_and_lstadd_back(path_list, split[i++]) == UTIL_ERROR)
+	{
+		if (!ft_strcmp(split[i], "."))
+			i++;
+		else if (ft_lstnew_and_lstadd_back(path_list, split[i++]) == UTIL_ERROR)
 			break ;
+	}
 	ft_free_split(&split);
 	if (0 < i && !*path_list)
 		return (UTIL_ERROR);

--- a/srcs/cd_fullpath.c
+++ b/srcs/cd_fullpath.c
@@ -1,0 +1,103 @@
+#include "minishell_sikeda.h"
+
+static int
+	make_current_path_list(t_list **path_list)
+{
+	char	**split;
+	size_t	i;
+
+	split = ft_split(g_pwd, '/');
+	if (!split)
+		return (UTIL_ERROR);
+	*path_list = NULL;
+	i = 0;
+	while (split[i])
+		if (ft_lstnew_and_lstadd_back(path_list, split[i++]) == UTIL_ERROR)
+			break ;
+	ft_free_split(&split);
+	if (0 < i && !*path_list)
+		return (UTIL_ERROR);
+	return (UTIL_SUCCESS);
+}
+
+static char
+	*generate_path(const t_list *path_list)
+{
+	char	*path;
+	char	*tmp;
+
+	if (!path_list)
+		path = ft_strdup("/");
+	else
+	{
+		tmp = ft_strdup("");
+		if (!tmp)
+			return (NULL);
+		while (path_list)
+		{
+			path = ft_join_path(tmp, path_list->content);
+			ft_free(&tmp);
+			if (!path)
+				return (NULL);
+			tmp = path;
+			path_list = path_list->next;
+		}
+	}
+	return (path);
+}
+
+static int
+	make_path_list(t_list **path_list,
+		const char *input_path, char **input_split, size_t *i)
+{
+	*path_list = NULL;
+	*i = 0;
+	if (input_path && *input_path == '/')
+	{
+		while (input_split[*i])
+		{
+			if (ft_strcmp(input_split[*i], "..")
+				&& ft_strcmp(input_split[*i], "."))
+			{
+				if (ft_lstnew_and_lstadd_back(path_list, input_split[(*i)++])
+					== UTIL_ERROR)
+					ft_free_split_and_return_int(&input_split, UTIL_ERROR);
+			}
+			else
+				break ;
+		}
+	}
+	else if (make_current_path_list(path_list) == UTIL_ERROR)
+		ft_free_split_and_return_int(&input_split, UTIL_ERROR);
+	return (UTIL_SUCCESS);
+}
+
+char
+	*ft_make_full_path(const char *input_path)
+{
+	char	*full_path;
+	char	**input_split;
+	t_list	*path_list;
+	size_t	i;
+
+	input_split = ft_split(input_path, '/');
+	if (!input_split)
+		return (NULL);
+	if (make_path_list(&path_list, input_path, input_split, &i) == UTIL_ERROR)
+		return (NULL);
+	while (input_split[i])
+	{
+		if (!ft_strcmp(input_split[i], ".."))
+			ft_lstdelend(&path_list, free);
+		else if (!ft_strcmp(input_split[i], "."))
+			;
+		else if (ft_lstnew_and_lstadd_back(&path_list, input_split[i])
+			== UTIL_ERROR)
+			ft_free_split_and_return_str(&input_split, NULL);
+		i++;
+	}
+	ft_free_split(&input_split);
+	full_path = generate_path(path_list);
+	ft_lstclear(&path_list, free);
+	return (full_path);
+}

--- a/srcs/cd_path_utils.c
+++ b/srcs/cd_path_utils.c
@@ -1,0 +1,17 @@
+#include "minishell_sikeda.h"
+
+char
+	*ft_join_path(const char *path, const char *new)
+{
+	char	*tmp;
+	char	*result;
+
+	if (!path || !new)
+		return (NULL);
+	tmp = ft_strjoin(path, "/");
+	if (!tmp)
+		return (NULL);
+	result = ft_strjoin(tmp, new);
+	free(tmp);
+	return (result);
+}

--- a/srcs/cd_path_utils.c
+++ b/srcs/cd_path_utils.c
@@ -15,3 +15,21 @@ char
 	free(tmp);
 	return (result);
 }
+
+char
+	*ft_get_home_path(const char *args)
+{
+	char	*path;
+
+	if (!args)
+	{
+		path = ft_getenv("HOME");
+		if (!path)
+		{
+			ft_put_cmderror("cd", "HOME not set");
+			return (NULL);
+		}
+		return (path);
+	}
+	return ((char *)args);
+}

--- a/srcs/utils/split_utils.c
+++ b/srcs/utils/split_utils.c
@@ -1,0 +1,33 @@
+#include "minishell_sikeda.h"
+
+void
+	ft_free_split(char ***split)
+{
+	size_t	i;
+
+	i = 0;
+	if (!*split)
+		return ;
+	while ((*split)[i])
+	{
+		free((*split)[i]);
+		(*split)[i] = NULL;
+		i++;
+	}
+	free(*split);
+	*split = NULL;
+}
+
+char
+	*ft_free_split_and_return_str(char ***split, const char *return_value)
+{
+	ft_free_split(split);
+	return ((char *)return_value);
+}
+
+int
+	ft_free_split_and_return_int(char ***split, const int return_value)
+{
+	ft_free_split(split);
+	return (return_value);
+}

--- a/srcs/utils/tlist_utils.c
+++ b/srcs/utils/tlist_utils.c
@@ -1,0 +1,41 @@
+#include "minishell_sikeda.h"
+
+void
+	ft_lstdelend(t_list **lst, void (*del)(void*))
+{
+	t_list	*prev;
+	t_list	*current;
+
+	if (!lst || !del)
+		return ;
+	current = *lst;
+	prev = NULL;
+	while (current && current->next)
+	{
+		prev = current;
+		current = current->next;
+	}
+	ft_lstdelone(current, del);
+	if (prev)
+		prev->next = NULL;
+}
+
+int
+	ft_lstnew_and_lstadd_back(t_list **path_list, const char *str)
+{
+	t_list	*new;
+	char	*tmp;
+
+	new = NULL;
+	tmp = ft_strdup(str);
+	if (tmp)
+		new = ft_lstnew(tmp);
+	if (!tmp || !new)
+	{
+		ft_free(&tmp);
+		ft_lstclear(path_list, free);
+		return (UTIL_ERROR);
+	}
+	ft_lstadd_back(path_list, new);
+	return (UTIL_SUCCESS);
+}

--- a/test/test_builtin.h
+++ b/test/test_builtin.h
@@ -10,5 +10,10 @@ int	test_finalize_minishell(char ***args_head, const int exit_code);
 int	test_commands(char **args);
 /* test_launch.c */
 int	test_launch(char **args);
+/* test_cd.c */
+int	test_cd(char **args, const t_bool is_nodir);
+int	test_cdnodir(char **args);
+int	test_cdnodir2(char **args);
+int	test_cd_and_pwd(char **args);
 
 #endif

--- a/test/test_cd.c
+++ b/test/test_cd.c
@@ -1,0 +1,60 @@
+#include "test_builtin.h"
+
+int
+	test_cd(char **args, const t_bool is_nodir)
+{
+	const char	*pwdargs[] = {"pwd", NULL};
+	int			ret;
+
+	ret = ft_cd(args);
+	if (g_status == STATUS_SUCCESS || is_nodir == TRUE)
+	{
+		ft_pwd((char **)pwdargs);
+		printf("PWD: %s\n", ft_getenv("PWD"));
+		printf("OLDPWD: %s\n", ft_getenv("OLDPWD"));
+	}
+	return (ret);
+}
+
+int
+	test_cdnodir(char **args)
+{
+	const char	*args1[] = {"mkdir", "cdtest", NULL};
+	const char	*args2[] = {"cd", "cdtest", NULL};
+	const char	*args3[] = {"rmdir", "../cdtest", NULL};
+	int			ret;
+
+	test_launch((char **)args1);
+	ret = ft_cd((char **)args2);
+	test_launch((char **)args3);
+	ret = test_cd(args, TRUE);
+	return (ret);
+}
+
+int
+	test_cdnodir2(char **args)
+{
+	const char	*args1[] = {"mkdir", "cdtest", NULL};
+	const char	*args2[] = {"cd", "cdtest", NULL};
+	const char	*args3[] = {"rmdir", "../cdtest", NULL};
+	const char	*args4[] = {"cd", "..", NULL};
+	int			ret;
+
+	test_launch((char **)args1);
+	ret = ft_cd((char **)args2);
+	test_launch((char **)args3);
+	ret = test_cd(args, FALSE);
+	ret = test_cd((char **)args4, TRUE);
+	return (ret);
+}
+
+int
+	test_cd_and_pwd(char **args)
+{
+	int	ret;
+
+	ret = ft_pwd(args);
+	ret = ft_cd(args);
+	ret = ft_pwd(args);
+	return (ret);
+}

--- a/test/test_exec.c
+++ b/test/test_exec.c
@@ -1,47 +1,5 @@
 #include "test_builtin.h"
 
-static int
-	exec_cd_test(char **args, const t_bool is_nodir)
-{
-	const char	*pwdargs[] = {"pwd", NULL};
-	int			ret;
-
-	ret = ft_cd(args);
-	if (g_status == STATUS_SUCCESS || is_nodir == TRUE)
-	{
-		ft_pwd((char **)pwdargs);
-		printf("PWD: %s\n", ft_getenv("PWD"));
-		printf("OLDPWD: %s\n", ft_getenv("OLDPWD"));
-	}
-	return (ret);
-}
-
-static int
-	exec_cdnodir_test(char **args)
-{
-	const char	*args1[] = {"mkdir", "cdtest", NULL};
-	const char	*args2[] = {"cd", "cdtest", NULL};
-	const char	*args3[] = {"rmdir", "../cdtest", NULL};
-	int			ret;
-
-	test_launch((char **)args1);
-	ret = ft_cd((char **)args2);
-	test_launch((char **)args3);
-	exec_cd_test(args, TRUE);
-	return (ret);
-}
-
-static int
-	exec_cd_and_pwd(char **args)
-{
-	int	ret;
-
-	ret = ft_pwd(args);
-	ret = ft_cd(args);
-	ret = ft_pwd(args);
-	return (ret);
-}
-
 int
 	test_commands(char **args)
 {
@@ -51,13 +9,15 @@ int
 	if (!ft_strcmp(args[1], "echo"))
 		ret = ft_echo(++args);
 	else if (!ft_strcmp(args[1], "cd"))
-		ret = exec_cd_test(++args, FALSE);
+		ret = test_cd(++args, FALSE);
 	else if (!ft_strcmp(args[1], "cd_nodir"))
-		ret = exec_cdnodir_test(++args);
+		ret = test_cdnodir(++args);
+	else if (!ft_strcmp(args[1], "cd_nodir2"))
+		ret = test_cdnodir2(++args);
 	else if (!ft_strcmp(args[1], "pwd"))
 		ret = ft_pwd(++args);
 	else if (!ft_strcmp(args[1], "cd_pwd"))
-		ret = exec_cd_and_pwd(++args);
+		ret = test_cd_and_pwd(++args);
 	else if (!ft_strcmp(args[1], "env"))
 		ret = ft_env(++args);
 	else if (!ft_strcmp(args[1], "export"))

--- a/test/test_exec.c
+++ b/test/test_exec.c
@@ -22,14 +22,12 @@ static int
 	const char	*args1[] = {"mkdir", "cdtest", NULL};
 	const char	*args2[] = {"cd", "cdtest", NULL};
 	const char	*args3[] = {"rmdir", "../cdtest", NULL};
-	const char	*args4[] = {"cd", "", NULL};
 	int			ret;
 
-	(void)args;
 	test_launch((char **)args1);
 	ret = ft_cd((char **)args2);
 	test_launch((char **)args3);
-	exec_cd_test((char **)args4, TRUE);
+	exec_cd_test(args, TRUE);
 	return (ret);
 }
 


### PR DESCRIPTION
# 概要
issue #112 cd関数内でchdir成功後、カレントディレクトリとPWDの値をユーザ入力値から作成する
issue #107 カレントディレクトリが削除されたあとcd . ; pwd;

# 受入条件
内容確認、動作確認（cdtest.sh）

# コメント
- ファイル数が多くなりテストスクリプトのコンパイル部分が大変になったのでMakefileを作成しました。
- Makefileは「make」だけだと動かないと思います（mainが含まれていないので）
- Makefileはビルトインコマンドテスト用に以下の４つの特殊ルールがあります。これらはオブジェクトファイルを作らないので更新がないファイルも毎回コンパイルしますが、これはleaksチェック付きコンパイルを任意に行えるようにするための苦肉の策です。（テスト用ルールなのでレビュー評価では問題ないのかなと思っています）
  - btest：ビルトインコマンドテスト用コンパイル
  - bltest：ビルトインコマンドテスト用コンパイル（leaksのチェック付き）
  - cdtest：cdコマンドテスト用コンパイル
  - cdltest：cdコマンドテスト用コンパイル（leaksのチェック付き）
- 「./cdtest.sh」もしくは「bash cdtest.sh」で「make cdtest」をしてから各テストを行います。
- 「./cdtest.sh leaks」もしくは「bash cdtest.sh leaks」で「make cdltest」をしてからリークチェック付きの各テストを行います。

close #112 
close #107