### PR TITLE
Feature/multi pipe

### DIFF
--- a/includes/minishell_tnishina.h
+++ b/includes/minishell_tnishina.h
@@ -19,6 +19,7 @@
 # define PROMPT "minishell$ "
 # define EXIT_PROMPT "exit\n"
 # define STATUS_SYNTAX_ERR 258
+# define NEWLINE "newline"
 
 /*
 ** basic GNL parameters
@@ -34,7 +35,7 @@
 ** Error messages
 */
 
-# define QUOTATION_ERROR_MSG "multiline commands are not allowed"
+# define MULTILINE_ERROR_MSG "multiline commands are not allowed"
 # define SYNTAX_ERROR_MSG "syntax error near unexpected token"
 
 /*
@@ -59,6 +60,7 @@ typedef struct			s_command
 {
 	t_list				*args;
 	char				*op;
+	pid_t				pid;
 	struct s_command	*next;
 }						t_command;
 
@@ -70,5 +72,9 @@ void		ft_clear_commands(t_command **c);
 int			ft_expand_env_var(t_command *c);
 t_bool		ft_is_delimiter_or_quote(char *l, int i, int *fl);
 t_bool		ft_is_delimiter(char c);
+
+/* utils_tnishina.c */
+char		**ft_convert_list(t_list *l);
+void		ft_clear_argv(char ***argv);
 
 #endif

--- a/multipipetest.sh
+++ b/multipipetest.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+cd libft
+make bonus
+cd ..
+gcc -g -Wall -Wextra -Werror -I./includes -I./libft \
+    srcs/echo.c srcs/cd.c srcs/pwd.c srcs/exit.c srcs/env.c srcs/unset.c \
+    srcs/export.c srcs/export_print.c srcs/export_setenv.c \
+    srcs/init_env.c srcs/env_utils.c srcs/env_utils2.c srcs/env_sort.c srcs/env_copy.c \
+    srcs/utils/utils.c srcs/utils/minishell_errors.c srcs/utils/command_utils.c \
+	srcs/utils/command_errors.c srcs/utils/utils_tnishina.c srcs/minishell_multi.c\
+	srcs/make_command.c srcs/make_token.c srcs/get_next_line.c srcs/expand_env.c \
+    -Llibft -lft -o multipipe.out #-D LEAKS
+
+YELLOW=$(printf '\033[33m')
+CYAN=$(printf '\033[36m')
+RESET=$(printf '\033[0m')

--- a/srcs/make_command.c
+++ b/srcs/make_command.c
@@ -125,9 +125,6 @@ static t_command
 static t_bool
 	is_valid_command(t_command *c)
 {
-	t_command	*prev;
-
-	prev = NULL;
 	while (c)
 	{
 		if ((!(ft_strcmp(c->op, "|")) && !(c->args)) ||
@@ -136,12 +133,21 @@ static t_bool
 			ft_put_syntaxerror_with_token(c->op);
 			return (FALSE);
 		}
+		c = c->next;
+	}
+	return (TRUE);
+}
+
+static t_bool
+	is_valid_pipe(t_command *c)
+{
+	while (c)
+	{
 		if (!(ft_strcmp(c->op, "|")) && !(c->next))
 		{
 			ft_put_cmderror(c->op, MULTILINE_ERROR_MSG);
 			return (FALSE);
 		}
-		prev = c;
 		c = c->next;
 	}
 	return (TRUE);
@@ -169,6 +175,8 @@ int
 			return (clear_with_syntax_error(commands, NULL, &tmp));
 		tokens = tmp;
 	}
+	if (!(is_valid_pipe(*commands)))
+		return (clear_with_syntax_error(commands, NULL, NULL));
 	return (COMPLETED);
 }
 

--- a/srcs/make_command.c
+++ b/srcs/make_command.c
@@ -136,6 +136,11 @@ static t_bool
 			ft_put_syntaxerror_with_token(c->op);
 			return (FALSE);
 		}
+		if (!(ft_strcmp(c->op, "|")) && !(c->next))
+		{
+			ft_put_cmderror(c->op, MULTILINE_ERROR_MSG);
+			return (FALSE);
+		}
 		prev = c;
 		c = c->next;
 	}

--- a/srcs/make_token.c
+++ b/srcs/make_token.c
@@ -46,9 +46,9 @@ t_bool
 }
 
 static int
-	put_quotation_error(char *cpy, t_list **tokens)
+	exit_w_quotation_error(char *cpy, t_list **tokens)
 {
-	ft_put_cmderror(cpy, QUOTATION_ERROR_MSG);
+	ft_put_cmderror(cpy, MULTILINE_ERROR_MSG);
 	ft_lstclear(tokens, free);
 	g_status = 1;
 	return (COMPLETED);
@@ -87,7 +87,7 @@ int
 			return (exit_with_error(tokens, &cpy));
 		ft_lstadd_back(tokens, n);
 		if ((fl[0] || fl[1]) && !l[i])
-			return (put_quotation_error(cpy, tokens));
+			return (exit_w_quotation_error(cpy, tokens));
 		l = l[i] ? l + i + (!i || fl[0] || fl[1] || fl[2]) : l + i;
 	}
 	return (COMPLETED);

--- a/srcs/minishell_multi.c
+++ b/srcs/minishell_multi.c
@@ -1,0 +1,220 @@
+#include "minishell_tnishina.h"
+#include "minishell_sikeda.h"
+#include "libft.h"
+
+int
+	exit_with_error(void)
+{
+	ft_put_error(strerror(errno));
+	exit(g_status);
+}
+
+void
+	do_command(t_command *c, char **environ)
+{
+	char	**argv;
+	char	**paths;
+	char	*tmp;
+	char	*command;
+
+	if (!c || !environ)
+		exit(1);
+	argv = ft_convert_list(c->args);
+	if (!argv)
+		exit(1);
+	command = ft_strdup(argv[0]);
+	if (!command)
+		exit(1);
+	if (execve(argv[0], argv, environ) < 0)
+	{
+		paths = ft_split(ft_getenv("PATH"), ':');
+		while (*paths)
+		{
+			ft_free(&(argv[0]));
+			tmp = ft_strjoin(*paths, "/");
+			if (tmp)
+				argv[0] = ft_strjoin(tmp, command);
+			ft_free(&tmp);
+			if (!argv[0])
+				exit(1);
+			if (execve(argv[0], argv, environ) < 0)
+				paths++;
+		}
+		ft_put_cmderror(command, "command not found");
+		ft_free(&command);
+		exit(1);
+	}
+}
+
+static t_bool
+	is_pipe(t_command *c)
+{
+	if (!ft_strncmp(c->op, "|", ft_strlen("|") + 1))
+		return (TRUE);
+	else
+		return (FALSE);
+}
+
+int
+	ft_execute_builtin(t_command *c)
+{
+	char	**argv;
+	int		res;
+
+	res = STOP;
+	argv = ft_convert_list(c->args);
+	if (!argv)
+	{
+		g_status = 1;
+		return (STOP);
+	}
+	if (!ft_strcmp(argv[0], "echo"))
+		res = ft_echo(argv);
+	else if (!ft_strcmp(argv[0], "cd"))
+		res = ft_cd(argv);
+	else if (!ft_strcmp(argv[0], "pwd"))
+		res = ft_pwd(argv);
+	else if (!ft_strcmp(argv[0], "export"))
+		res = ft_export(argv);
+	else if (!ft_strcmp(argv[0], "unset"))
+		res = ft_unset(argv);
+	else if (!ft_strcmp(argv[0], "env"))
+		res = ft_env(argv);
+	else if (!ft_strcmp(argv[0], "exit"))
+		res = ft_exit(argv);
+	ft_clear_argv(&argv);
+	return (res);
+}
+
+static t_bool
+	is_builtin(t_command *c)
+{
+	if (!ft_strcmp((char* )(c->args->content), "echo")
+		|| !ft_strcmp((char* )(c->args->content), "cd")
+		|| !ft_strcmp((char* )(c->args->content), "pwd")
+		|| !ft_strcmp((char* )(c->args->content), "export")
+		|| !ft_strcmp((char* )(c->args->content), "unset")
+		|| !ft_strcmp((char* )(c->args->content), "env")
+		|| !ft_strcmp((char* )(c->args->content), "exit"))
+		return (TRUE);
+	else
+		return (FALSE);
+}
+
+static pid_t
+	start_command(t_command *c, t_bool ispipe, t_bool haspipe, int lastpipe[2], char **environ)
+{
+	pid_t	pid;
+	int		newpipe[2];
+
+	if (ispipe)
+		pipe(newpipe);
+	pid = fork();
+	if (pid == 0)
+	{
+		if (haspipe)
+		{
+			close(lastpipe[1]);
+			dup2(lastpipe[0], STDIN_FILENO);
+			close(lastpipe[0]);
+		}
+		if (ispipe)
+		{
+			close(newpipe[0]);
+			dup2(newpipe[1], STDOUT_FILENO);
+			close(newpipe[1]);
+		}
+		do_command(c, environ);
+	}
+	if (haspipe)
+	{
+		close(lastpipe[0]);
+		close(lastpipe[1]);
+	}
+	if (ispipe)
+	{
+		lastpipe[0] = newpipe[0];
+		lastpipe[1] = newpipe[1];
+	}
+	return (pid);
+}
+
+t_command
+	*ft_execute_pipeline(t_command *c, char **environ)
+{
+	t_bool	haspipe;
+	int		lastpipe[2];
+
+	haspipe = FALSE;
+	ft_memset(lastpipe, -1, sizeof(int) * 2);
+	while (c)
+	{
+		c->pid = start_command(c, is_pipe(c), haspipe, lastpipe, environ);
+		haspipe = is_pipe(c);
+		if (haspipe)
+			c = c->next;
+		else
+			break ;
+	}
+	return (c);
+}
+
+int
+	main(void)
+{
+	char		*line;
+	char		*trimmed;
+	extern char	**environ;
+	t_list		*tokens;
+	t_command	*head;
+	t_command	*commands;
+
+	if (ft_init_env() == STOP)
+		return (EXIT_FAILURE);
+	if (ft_init_pwd() == STOP)
+	{
+		ft_lstclear(&g_env, free);
+		return (EXIT_FAILURE);
+	}
+	ft_putstr_fd(PROMPT, STDOUT_FILENO);
+	while (get_next_line(STDIN_FILENO, &line) == 1
+		&& (trimmed = ft_strtrim(line, " \t")))
+	{
+		if ((ft_make_token(&tokens, trimmed, ft_is_delimiter_or_quote) != COMPLETED)
+		|| ft_make_command(&commands, tokens) != COMPLETED
+		|| ft_expand_env_var(commands) != COMPLETED)
+		{
+			ft_free(&line);
+			ft_free(&trimmed);
+			ft_lstclear(&tokens, free);
+			return (1);
+		}
+		head = commands;
+		while (commands)
+		{
+			if (is_builtin(commands) && !is_pipe(commands))
+			{
+				if (ft_execute_builtin(commands) != KEEP_RUNNING)
+					exit(g_status);
+				commands = commands->next;
+				continue ;
+			}
+			commands = ft_execute_pipeline(commands, environ);
+			if (waitpid(commands->pid, &g_status, 0) < 0)
+				exit_with_error();
+			commands = commands->next;
+		}
+		ft_free(&line);
+		ft_free(&trimmed);
+		get_next_line(STDIN_FILENO, NULL);
+		ft_clear_commands(&head);
+		ft_putstr_fd(PROMPT, STDOUT_FILENO);
+	}
+	ft_free(&line);
+	ft_free(&trimmed);
+	get_next_line(STDIN_FILENO, NULL);
+	ft_free(&g_pwd);
+	ft_lstclear(&g_env, free);
+	ft_putstr_fd(EXIT_PROMPT, STDOUT_FILENO);
+	exit(g_status);
+}

--- a/srcs/utils/utils_tnishina.c
+++ b/srcs/utils/utils_tnishina.c
@@ -1,0 +1,48 @@
+#include "minishell_tnishina.h"
+#include "minishell_sikeda.h"
+#include "libft.h"
+
+char
+	**ft_convert_list(t_list *l)
+{
+	char	**argv;
+	char	**head;
+
+	if (!l)
+		return (NULL);
+	argv = (char** )malloc(sizeof(char* ) * (ft_lstsize(l) + 1));
+	if (!argv)
+		return (NULL);
+	head = argv;
+	ft_memset(argv, 0, sizeof(char* ) * (ft_lstsize(l) + 1));
+	while (l)
+	{
+		*argv = ft_strdup((char* )(l->content));
+		if (!*argv)
+		{
+			ft_clear_argv(&head);
+			ft_put_error(strerror(errno));
+			return (NULL);
+		}
+		argv++;
+		l = l->next;
+	}
+	*argv = NULL;
+	return (head);
+}
+
+void
+	ft_clear_argv(char ***argv)
+{
+	char	**head;
+
+	if (*argv)
+		head = *argv;
+	while (**argv)
+	{
+		ft_free(*argv);
+		(*argv)++;
+	}
+	free(head);
+	head = NULL;
+}


### PR DESCRIPTION
#  概要
- 多段パイプの実装
- t_list型の変数をsplit型に変換する関数の実装

# 受入条件
動作確認、内容確認

# コメント
- bash multipipetest.sh; ./multipipe.outで実行できます
- リダイレクトのプルリクとだいぶコンフリクトが起こりそうだったので、minishell_multi.cという別ファイルを作っています
- 合わせて、echo | のようにパイプでコマンドが終わっている場合のエラー出力を追加しました
- テストケース、全然書けておらず、すいません。。。

close #18 