### PR TITLE
add #20 #21 #22 functions to handle signals

### DIFF
--- a/includes/minishell_tnishina.h
+++ b/includes/minishell_tnishina.h
@@ -84,4 +84,8 @@ void		ft_put_fderror(int fd_from);
 char		**ft_convert_list(t_list *l);
 void		ft_clear_argv(char ***argv);
 
+/* handle_signal.c */
+void		ft_sig_prior(void);
+void		ft_sig_post(void);
+
 #endif

--- a/signaltest.sh
+++ b/signaltest.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+cd libft
+make bonus
+cd ..
+gcc -g -Wall -Wextra -Werror -I./includes -I./libft \
+    srcs/cd.c srcs/cd_error.c srcs/cd_path_utils.c srcs/cd_fullpath.c \
+	srcs/echo.c srcs/pwd.c srcs/exit.c \
+	srcs/env.c srcs/unset.c \
+    srcs/export.c srcs/export_print.c srcs/export_setenv.c \
+    srcs/init_env.c srcs/env_utils.c srcs/env_utils2.c \
+    srcs/env_sort.c srcs/env_copy.c \
+    srcs/utils/utils.c srcs/utils/minishell_errors.c srcs/utils/command_utils.c \
+	srcs/utils/command_errors.c srcs/utils/utils_tnishina.c srcs/minishell_signal.c\
+	srcs/make_command.c srcs/make_token.c srcs/get_next_line.c srcs/expand_env.c \
+    srcs/utils/tlist_utils.c srcs/utils/split_utils.c srcs/handle_signal.c\
+    -Llibft -lft -o signal.out #-D LEAKS

--- a/srcs/handle_signal.c
+++ b/srcs/handle_signal.c
@@ -1,0 +1,58 @@
+#include "minishell_tnishina.h"
+#include "minishell_sikeda.h"
+#include "libft.h"
+
+void
+	sig_int_prior()
+{
+	ft_putstr_fd("\b\b  \b\b\n", STDERR_FILENO);
+	ft_putstr_fd(PROMPT, STDERR_FILENO);
+}
+
+void
+	sig_quit_prior()
+{
+	ft_putstr_fd("\b\b  \b\b", STDERR_FILENO);
+}
+
+void
+	sig_int_post()
+{
+	ft_putstr_fd("\n", STDERR_FILENO);
+}
+
+void
+	sig_quit_post()
+{
+	ft_putstr_fd("Quit: 3\n", STDERR_FILENO);
+}
+
+void
+	ft_sig_prior(void)
+{
+	if (signal(SIGINT, sig_int_prior) == SIG_ERR)
+	{
+		ft_putstr_fd(strerror(errno), STDERR_FILENO);
+		exit(1);
+	}
+	if (signal(SIGQUIT, SIG_IGN) == SIG_ERR)
+	{
+		ft_putstr_fd(strerror(errno), STDERR_FILENO);
+		exit(1);
+	}
+}
+
+void
+	ft_sig_post(void)
+{
+	if (signal(SIGINT, sig_int_post) == SIG_ERR)
+	{
+		ft_putstr_fd(strerror(errno), STDERR_FILENO);
+		exit(1);
+	}
+	if (signal(SIGQUIT, sig_quit_post) == SIG_ERR)
+	{
+		ft_putstr_fd(strerror(errno), STDERR_FILENO);
+		exit(1);
+	}
+}

--- a/srcs/handle_signal.c
+++ b/srcs/handle_signal.c
@@ -7,24 +7,21 @@ void
 {
 	ft_putstr_fd("\b\b  \b\b\n", STDERR_FILENO);
 	ft_putstr_fd(PROMPT, STDERR_FILENO);
-}
-
-void
-	sig_quit_prior()
-{
-	ft_putstr_fd("\b\b  \b\b", STDERR_FILENO);
+	g_status = 1;
 }
 
 void
 	sig_int_post()
 {
 	ft_putstr_fd("\n", STDERR_FILENO);
+	g_status = 130;
 }
 
 void
 	sig_quit_post()
 {
 	ft_putstr_fd("Quit: 3\n", STDERR_FILENO);
+	g_status = 131;
 }
 
 void

--- a/srcs/minishell_signal.c
+++ b/srcs/minishell_signal.c
@@ -1,0 +1,228 @@
+#include "minishell_tnishina.h"
+#include "minishell_sikeda.h"
+#include "libft.h"
+
+int
+	exit_with_error(void)
+{
+	ft_put_error(strerror(errno));
+	exit(g_status);
+}
+
+void
+	do_command(t_command *c, char **environ)
+{
+	char	**argv;
+	char	**paths;
+	char	*tmp;
+	char	*command;
+
+	if (!c || !environ)
+		exit(1);
+	argv = ft_convert_list(c->args);
+	if (!argv)
+		exit(1);
+	command = ft_strdup(argv[0]);
+	if (!command)
+		exit(1);
+	if (execve(argv[0], argv, environ) < 0)
+	{
+		paths = ft_split(ft_getenv("PATH"), ':');
+		while (*paths)
+		{
+			ft_free(&(argv[0]));
+			tmp = ft_strjoin(*paths, "/");
+			if (tmp)
+				argv[0] = ft_strjoin(tmp, command);
+			ft_free(&tmp);
+			if (!argv[0])
+				exit(1);
+			if (execve(argv[0], argv, environ) < 0)
+				paths++;
+		}
+		ft_put_cmderror(command, "command not found");
+		ft_free(&command);
+		exit(1);
+	}
+}
+
+static t_bool
+	is_pipe(t_command *c)
+{
+	if (!ft_strncmp(c->op, "|", ft_strlen("|") + 1))
+		return (TRUE);
+	else
+		return (FALSE);
+}
+
+int
+	ft_execute_builtin(t_command *c)
+{
+	char	**argv;
+	int		res;
+
+	res = STOP;
+	argv = ft_convert_list(c->args);
+	if (!argv)
+	{
+		g_status = 1;
+		return (STOP);
+	}
+	if (!ft_strcmp(argv[0], "echo"))
+		res = ft_echo(argv);
+	else if (!ft_strcmp(argv[0], "cd"))
+		res = ft_cd(argv);
+	else if (!ft_strcmp(argv[0], "pwd"))
+		res = ft_pwd(argv);
+	else if (!ft_strcmp(argv[0], "export"))
+		res = ft_export(argv);
+	else if (!ft_strcmp(argv[0], "unset"))
+		res = ft_unset(argv);
+	else if (!ft_strcmp(argv[0], "env"))
+		res = ft_env(argv);
+	else if (!ft_strcmp(argv[0], "exit"))
+		res = ft_exit(argv);
+	ft_clear_argv(&argv);
+	return (res);
+}
+
+static t_bool
+	is_builtin(t_command *c)
+{
+	if (!ft_strcmp((char* )(c->args->content), "echo")
+		|| !ft_strcmp((char* )(c->args->content), "cd")
+		|| !ft_strcmp((char* )(c->args->content), "pwd")
+		|| !ft_strcmp((char* )(c->args->content), "export")
+		|| !ft_strcmp((char* )(c->args->content), "unset")
+		|| !ft_strcmp((char* )(c->args->content), "env")
+		|| !ft_strcmp((char* )(c->args->content), "exit"))
+		return (TRUE);
+	else
+		return (FALSE);
+}
+
+static pid_t
+	start_command(t_command *c, t_bool ispipe, t_bool haspipe, int lastpipe[2], char **environ)
+{
+	pid_t	pid;
+	int		newpipe[2];
+
+	if (ispipe)
+		pipe(newpipe);
+	pid = fork();
+	if (pid == 0)
+	{
+		if (haspipe)
+		{
+			close(lastpipe[1]);
+			dup2(lastpipe[0], STDIN_FILENO);
+			close(lastpipe[0]);
+		}
+		if (ispipe)
+		{
+			close(newpipe[0]);
+			dup2(newpipe[1], STDOUT_FILENO);
+			close(newpipe[1]);
+		}
+		do_command(c, environ);
+	}
+	if (haspipe)
+	{
+		close(lastpipe[0]);
+		close(lastpipe[1]);
+	}
+	if (ispipe)
+	{
+		lastpipe[0] = newpipe[0];
+		lastpipe[1] = newpipe[1];
+	}
+	return (pid);
+}
+
+t_command
+	*ft_execute_pipeline(t_command *c, char **environ)
+{
+	t_bool	haspipe;
+	int		lastpipe[2];
+
+	haspipe = FALSE;
+	ft_memset(lastpipe, -1, sizeof(int) * 2);
+	while (c)
+	{
+		c->pid = start_command(c, is_pipe(c), haspipe, lastpipe, environ);
+		haspipe = is_pipe(c);
+		if (haspipe)
+			c = c->next;
+		else
+			break ;
+	}
+	return (c);
+}
+
+int
+	main(void)
+{
+	char		*line;
+	char		*trimmed;
+	extern char	**environ;
+	int			res;
+	t_list		*tokens;
+	t_command	*head;
+	t_command	*commands;
+
+	if (ft_init_env() == STOP)
+		return (EXIT_FAILURE);
+	if (ft_init_pwd() == STOP)
+	{
+		ft_lstclear(&g_env, free);
+		return (EXIT_FAILURE);
+	}
+	while (1)
+	{
+		ft_putstr_fd(PROMPT, STDOUT_FILENO);
+		ft_sig_prior();
+		res = get_next_line(STDIN_FILENO, &line);
+		if (res == 0 && ft_strlen(line) == 0)
+		{
+			ft_putstr_fd(EXIT_PROMPT, STDERR_FILENO);
+			exit (0);
+		}
+		ft_sig_post();
+		trimmed = ft_strtrim(line, " \t");
+		if ((ft_make_token(&tokens, trimmed, ft_is_delimiter_or_quote) != COMPLETED)
+			|| ft_make_command(&commands, tokens) != COMPLETED
+			|| ft_expand_env_var(commands) != COMPLETED)
+		{
+			ft_free(&line);
+			ft_free(&trimmed);
+			ft_lstclear(&tokens, free);
+			return (1);
+		}
+		head = commands;
+		while (commands)
+		{
+			if (is_builtin(commands) && !is_pipe(commands))
+			{
+				if (ft_execute_builtin(commands) != KEEP_RUNNING)
+					exit(g_status);
+				commands = commands->next;
+				continue ;
+			}
+			commands = ft_execute_pipeline(commands, environ);
+			if (waitpid(commands->pid, &g_status, 0) < 0)
+				exit_with_error();
+			commands = commands->next;
+		}
+		ft_free(&line);
+		ft_free(&trimmed);
+		get_next_line(STDIN_FILENO, NULL);
+		ft_clear_commands(&head);
+	}
+	ft_free(&line);
+	ft_free(&trimmed);
+	get_next_line(STDIN_FILENO, NULL);
+	ft_free(&g_pwd);
+	ft_lstclear(&g_env, free);
+	ft_putstr_fd(EXIT_PROMPT, STDOUT_FILENO);
+	exit(g_status);
+}


### PR DESCRIPTION
# 概要
ctrl-C, ctrl-D, ctrl-\の実装

# 受入条件
内容確認、動作確認

# コメント
- bash signaltest.sh; ./signal.outで実行できます
- 添付の手書き資料の通り、現状の実装だと、コマンド入力中 (=プロンプトが表示された後に、コマンドを入力し、改行を押す前の段階)にctrl-D、ctrl-\を入力した際の挙動以外は再現できているかと思います
- 添付手書き資料に記載した各パターンの動きについては、それぞれ以下の方法で確認可能です
1. コマンド入力前：プロンプトだけが表示されている状態でctrl-C, ctrl-D, ctrl-\を入力
2. コマンド入力中：数文字コマンドを入力してからctrl-C, ctrl-D, ctrl-\を入力
3. コマンド入力後：sleep 5などでコマンドが処理されている状態でctrl-C, ctrl-D, ctrl-\を入力、でそれぞれ確認できるかと思います
- 手書き資料にも書かせて頂いた通り、現在実装できていないと認識している2パターンについては、termcapを使った入力処理を実装される際に含められないかと思っております。合わせてご確認いただけると幸いです。

close #20 
close #21 
close #22 

![42 P1 3](https://user-images.githubusercontent.com/15176241/116574994-36153b80-a949-11eb-84d8-932a16ac49a3.png)
