### PR TITLE
Feature/init termcap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 NAME		:= minishell
 
 UTILDIR		:= ./srcs/utils/
+TERMDIR		:= ./srcs/termcaps/
 
 SRCS		:=
 SRCS		+= srcs/cd.c srcs/cd_error.c srcs/cd_path_utils.c srcs/cd_fullpath.c \
@@ -17,14 +18,19 @@ SRCS_BUITINTEST	:= $(SRCS)
 SRCS_BUITINTEST	+= test/test_builtin.c test/test_init.c test/test_exec.c test/test_launch.c test/test_cd.c
 OBJS_BUITINTEST	= $(SRCS_BUITINTEST:.c=.o)
 
+SRCS_TERMTEST	:= $(SRCS)
+SRCS_TERMTEST	+= $(TERMDIR)init_term.c
+SRCS_TERMTEST	+= srcs/minishell_term.c srcs/get_next_line.c srcs/make_token.c srcs/make_command.c srcs/expand_env.c
+OBJS_TERMTEST	= $(SRCS_TERMTEST:.c=.o)
+
 INCLUDE		:= -I./includes/ -I./libft/ -I./test/
 
 LIBDIR		:= ./libft
 LIBPATH		:= $(LIBDIR)/libft.a
 
 CC			:= gcc
-CFLAGS		:= -Wall -Wextra -Werror
-# DEBUG		:= -g -fsanitize=address
+CFLAGS		:= -Wall -Wextra -Werror -lcurses
+# DEBUG		:= -g -fsanitize=address -lcurses
 DEBUG		:=
 
 RM			:= rm -f
@@ -55,6 +61,10 @@ cdltest:	$(LIBPATH)
 			$(CC) $(CFLAGS) $(SRCS_BUITINTEST) $(DEBUG) $(INCLUDE) $(LIBPATH) -D CDTEST -D LEAKS -o builtin.out
 			@echo $(C_GREEN)"=== Make Done ==="
 
+termtest:	$(LIBPATH)
+			$(CC) $(CFLAGS) $(SRCS_TERMTEST) $(DEBUG) $(INCLUDE) $(LIBPATH) -D TEST -o term.out
+			@echo $(C_GREEN)"=== Make Done ==="
+
 $(LIBPATH):
 			$(MAKE) bonus -C $(LIBDIR)
 
@@ -69,4 +79,4 @@ fclean:		clean
 
 re:			fclean $(NAME)
 
-.PHONY:		all clean fclean re btest bltest cdtest cdltest
+.PHONY:		all clean fclean re btest bltest cdtest cdltest termtest

--- a/includes/minishell_sikeda.h
+++ b/includes/minishell_sikeda.h
@@ -8,6 +8,7 @@
 # include <string.h>
 # include <errno.h>
 # include "libft.h"
+# include "termcaps.h"
 
 # define PRG_NAME "minishell"
 
@@ -29,8 +30,6 @@
 
 # define SPACE_CHARS " \t\n\v\f\r"
 
-# define FREE(p) ((p) ? free(p) : (p), (p) = NULL)
-
 typedef enum e_bool
 {
 	FALSE,
@@ -43,9 +42,16 @@ typedef enum e_cmd_signal
 	STOP
 }	t_cmd_signal;
 
-int		g_status;
-char	*g_pwd;
-t_list	*g_env;
+typedef struct s_minishell
+{
+	struct termios	term;
+	struct termios	saved_term;
+}	t_minishell;
+
+t_minishell	g_ms;
+int			g_status;
+char		*g_pwd;
+t_list		*g_env;
 
 /* utils/minishell_errors.c */
 void	ft_put_error(char *msg);

--- a/includes/minishell_sikeda.h
+++ b/includes/minishell_sikeda.h
@@ -44,8 +44,8 @@ typedef enum e_cmd_signal
 
 typedef struct s_minishell
 {
-	struct termios	term;
-	struct termios	saved_term;
+	struct termios	ms_term;
+	struct termios	origin_term;
 }	t_minishell;
 
 t_minishell	g_ms;

--- a/includes/termcaps.h
+++ b/includes/termcaps.h
@@ -1,0 +1,21 @@
+#ifndef TERMCAPS_H
+# define TERMCAPS_H
+
+# include <term.h>
+# include <termios.h>
+
+# define C_EOF 4
+# define C_DEL 127
+# define K_UP "\e[A"
+# define K_DOWN "\e[B"
+# define K_RIGHT "\e[C"
+# define K_LEFT "\e[D"
+
+# define K_HOME "\e[H"
+# define K_END "\e[F"
+
+/* init_term.c */
+int	ft_init_term(void);
+int	ft_finalize_term(void);
+
+#endif

--- a/includes/termcaps.h
+++ b/includes/termcaps.h
@@ -16,6 +16,5 @@
 
 /* init_term.c */
 int	ft_init_term(void);
-int	ft_finalize_term(void);
 
 #endif

--- a/srcs/minishell_term.c
+++ b/srcs/minishell_term.c
@@ -1,0 +1,355 @@
+#include "minishell_tnishina.h"
+#include "minishell_sikeda.h"
+#include "libft.h"
+
+int
+	exit_with_error(char *str)
+{
+	printf("%s: %s\n", str, strerror(errno));
+	exit(1);
+}
+
+void
+	do_command(t_command *c, char **environ)
+{
+	char	**argv;
+	char	**head;
+	char	*tmp;
+
+	if (!c || !environ)
+		exit(1);
+	if (!(argv = (char**)malloc(sizeof(char*) * (ft_lstsize(c->args) + 1))))
+		exit(1);
+	head = argv;
+	while (c->args)
+	{
+		*argv = c->args->content;
+		argv++;
+		c->args = c->args->next;
+	}
+	*argv = NULL;
+	argv = head;
+	tmp = argv[0];
+	if (!(argv[0] = ft_strjoin("/bin/", argv[0])))
+		exit_with_error("malloc");
+	FREE(tmp);
+	if (execve(argv[0], argv, environ) < 0)
+	{
+		tmp = argv[0];
+		if (!(argv[0] = ft_strjoin("/usr", argv[0])))
+			exit_with_error("malloc"); //おそらくこのケースもリークが出てしまっているので要修正
+		FREE(tmp);
+		if (execve(argv[0], argv, environ) < 0)
+			exit_with_error("execve"); //このケースもリークが出てしまっているので要修正
+	}
+}
+
+static void
+	close_n_wait(int pipefd[2], pid_t childs[2], int *status, int *res)
+{
+	close(pipefd[0]);
+	close(pipefd[1]);
+	*res = waitpid(childs[0], status, 0);
+	*res = waitpid(childs[1], status, 0);
+}
+
+static void
+	do_simple_pipe(t_command *commands, char **environ)
+{
+	int		pipefd[2];
+	int		res;
+	int		status;
+	pid_t	childs[2];
+
+	res = pipe(pipefd);
+	if ((childs[0] = fork()) < 0)
+		exit_with_error("fork");
+	else if (childs[0] == 0)
+	{
+		close(pipefd[0]);
+		dup2(pipefd[1], 1);
+		close(pipefd[1]);
+		do_command(commands, environ);
+	}
+	if ((childs[1] = fork()) < 0)
+		exit_with_error("fork");
+	else if (childs[1] == 0)
+	{
+		close(pipefd[1]);
+		dup2(pipefd[0], 0);
+		close(pipefd[0]);
+		do_command(commands->next, environ);
+	}
+	close_n_wait(pipefd, childs, &status, &res);
+}
+
+static t_bool
+	is_redirect(char *str)
+{
+	if (!ft_strncmp(str, REDIRECT_IN, ft_strlen(REDIRECT_IN))
+	|| !ft_strncmp(str, REDIRECT_OUT, ft_strlen(REDIRECT_OUT))
+	|| !ft_strncmp(str, APPEND_REDIRECT_OUT, ft_strlen(APPEND_REDIRECT_OUT)))
+		return (TRUE);
+	else
+		return (FALSE);
+}
+
+t_bool
+	ft_set_redirection(t_list **args)
+{
+	t_list	*head;
+	t_list	*prev;
+	int		fd_from;
+	int		fd_to;
+	char	*path;
+	char	*redirect_op;
+
+	prev = NULL;
+	head = *args;
+	fd_from = -1;
+	redirect_op = NULL;
+	path = NULL;
+	while (*args)
+	{
+		if (ft_isdigit(((char*)((*args)->content))[0]) && ft_isnumeric((char*)((*args)->content)) && is_redirect((char*)((*args)->next->content)))
+		{
+			fd_from = ft_atoi((char*)((*args)->content));
+			if (fd_from < 0 || FD_MAX < fd_from)
+			{
+				ft_put_fderror(fd_from);
+				g_status = 1;
+				return (FALSE);
+			}
+			redirect_op = ft_strdup((char*)((*args)->next->content));
+			path = ft_strdup((char*)((*args)->next->next->content));
+			if (!redirect_op || !path)
+			{
+				FREE(redirect_op);
+				FREE(path);
+				g_status = 1;
+				return (FALSE);
+			}
+			if (prev)
+				prev->next = (*args)->next->next->next;
+			else
+				head = (*args)->next->next->next;
+			ft_lstdelone((*args)->next->next, free);
+			ft_lstdelone((*args)->next, free);
+			ft_lstdelone((*args), free);
+			if (prev)
+				*args = prev->next;
+			else
+				*args = head;
+		}
+		else if (is_redirect((char*)((*args)->content)))
+		{
+			redirect_op = ft_strdup((char*)((*args)->content));
+			path = ft_strdup((char*)((*args)->next->content));
+			if (!redirect_op || !path)
+			{
+				FREE(redirect_op);
+				FREE(path);
+				g_status = 1;
+				return (FALSE);
+			}
+			if (prev)
+				prev->next = (*args)->next->next;
+			else
+				head = (*args)->next->next;
+			ft_lstdelone((*args)->next, free);
+			ft_lstdelone((*args), free);
+			if (prev)
+				*args = prev->next;
+			else
+				*args = head;
+		}
+		if (!redirect_op)
+		{
+			prev = *args;
+			*args = (*args)->next;
+		}
+		else if (!(ft_strcmp(redirect_op, APPEND_REDIRECT_OUT)))
+		{
+			fd_to = open(path, O_WRONLY | O_CREAT | O_APPEND, 0666);
+			if (fd_to < 0)
+			{
+				ft_put_cmderror(path, strerror(errno));
+				g_status = 1;
+				FREE(redirect_op);
+				FREE(path);
+				return (FALSE);
+			}
+			if (fd_from == -1)
+				fd_from = STDOUT_FILENO;
+			dup2(fd_to, fd_from);
+			close(fd_to);
+		}
+		else if (!(ft_strcmp(redirect_op, REDIRECT_OUT)))
+		{
+			fd_to = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+			if (fd_to < 0)
+			{
+				ft_put_cmderror(path, strerror(errno));
+				g_status = 1;
+				FREE(redirect_op);
+				FREE(path);
+				return (FALSE);
+			}
+			if (fd_from == -1)
+				fd_from = STDOUT_FILENO;
+			dup2(fd_to, fd_from);
+			close(fd_to);
+		}
+		else if (!(ft_strcmp(redirect_op, REDIRECT_IN)))
+		{
+			fd_to = open(path, O_RDONLY);
+			if (fd_to < 0)
+			{
+				ft_put_cmderror(path, strerror(errno));
+				g_status = 1;
+				FREE(redirect_op);
+				FREE(path);
+				return (FALSE);
+			}
+			if (fd_from == -1)
+				fd_from = STDIN_FILENO;
+			dup2(fd_to, fd_from);
+			close(fd_to);
+		}
+		FREE(redirect_op);
+		FREE(path);
+	}
+	*args = head;
+	return (TRUE);
+}
+
+int ft_putchar(int c)
+{
+	return (write(1, &c, 1));
+}
+
+int
+	get_line(int fd, char **line)
+{
+	ssize_t	len;
+	ssize_t	rc;
+	char	buf[4];
+
+	len = 0;
+	ft_bzero(buf, sizeof(buf));
+	rc = read(fd, buf, sizeof(buf) / sizeof(buf[0]));
+	while (0 <= rc)
+	{
+		if (*buf == '\n' || *buf == '\r')
+		{
+			write(STDOUT_FILENO, "\n", 1);
+			tputs(tgetstr("cr", 0), 1, ft_putchar);
+			len = 0;
+		}
+		else if (*buf == C_EOF && !len)
+		{
+			*line = ft_strdup("exit");
+			break ;
+		}
+		else if (*buf == C_DEL)
+			tputs(tgetstr("le", 0), 1, ft_putchar);
+		else if (!ft_strcmp(buf, K_LEFT))
+			tputs(tgetstr("le", 0), 1, ft_putchar);
+		else if (!ft_strcmp(buf, K_RIGHT))
+			tputs(tgetstr("nd", 0), 1, ft_putchar);
+		else if (ft_isprint(*buf) && buf[1] == '\0')
+		{
+			write(STDOUT_FILENO, buf, rc);
+			len++;
+		}
+		rc = read(fd, buf, sizeof(buf) / sizeof(buf[0]));
+	}
+	return (GNL_SUCCESS);
+}
+
+int
+	main(void)
+{
+	char		*line;
+	char		*trimmed;
+	pid_t		pid;
+	extern char	**environ;
+	t_list		*tokens;
+	t_command	*head;
+	t_command	*commands;
+
+	if (ft_init_env() == STOP)
+		return (EXIT_FAILURE);
+	if (ft_init_pwd() == STOP)
+	{
+		ft_lstclear(&g_env, free);
+		return (EXIT_FAILURE);
+	}
+	ft_putstr_fd(PROMPT, STDOUT_FILENO);
+	if (ft_init_term() == UTIL_ERROR)
+	{
+		printf("error\n");
+		ft_lstclear(&g_env, free);
+		FREE(g_pwd);
+		return (EXIT_FAILURE);
+	}
+	while (get_line(STDIN_FILENO, &line) == 1 &&
+		(trimmed = ft_strtrim(line, " \t")) &&
+		ft_strcmp(trimmed, "exit"))
+	{
+		if ((ft_make_token(&tokens, trimmed, ft_is_delimiter_or_quote) != COMPLETED)
+		|| ft_make_command(&commands, tokens) != COMPLETED
+		|| ft_expand_env_var(commands) != COMPLETED)
+		{
+			FREE(line);
+			FREE(trimmed);
+			ft_lstclear(&tokens, free);
+			ft_finalize_term();
+			return (1);
+		}
+		head = commands;
+		while (commands)
+		{
+			if (!ft_strcmp(commands->op, ";") || !ft_strcmp(commands->op, NEWLINE))
+			{
+				if ((pid = fork()) < 0)
+				{
+					ft_finalize_term();
+					exit_with_error("fork");
+				}
+				else if (pid == 0)
+				{
+					if (ft_set_redirection(&(commands->args)))
+						do_command(commands, environ);
+					//リダイレクトが失敗した場合にはそのままexitする形にしているのですが、exitする際にリークが出てしまっているので要修正
+					ft_finalize_term();
+					exit(g_status);
+				}
+				if ((pid = waitpid(pid, &g_status, 0)) < 0)
+				{
+					ft_finalize_term();
+					exit_with_error("wait");
+				}
+				commands = commands->next;
+			}
+			else if (!ft_strcmp(commands->op, "|"))
+			{
+				do_simple_pipe(commands, environ);
+				commands = commands->next->next;
+			}
+		}
+		FREE(line);
+		FREE(trimmed);
+		get_next_line(STDIN_FILENO, NULL);
+		ft_clear_commands(&head);
+		ft_putstr_fd(PROMPT, STDOUT_FILENO);
+	}
+	ft_finalize_term();
+	FREE(line);
+	FREE(trimmed);
+	get_next_line(STDIN_FILENO, NULL);
+	FREE(g_pwd);
+	ft_lstclear(&g_env, free);
+	ft_putstr_fd(EXIT_PROMPT, STDOUT_FILENO);
+	exit(0);
+}

--- a/srcs/termcaps/init_term.c
+++ b/srcs/termcaps/init_term.c
@@ -13,22 +13,18 @@ int
 		ft_put_error("Cannot find terminfo entry.");
 		return (UTIL_ERROR);
 	}
-	if (tcgetattr(STDIN_FILENO, &g_ms.term) != 0)
+	if (tcgetattr(STDIN_FILENO, &g_ms.ms_term) != 0)
 	{
 		ft_put_error(strerror(errno));
 		return (UTIL_ERROR);
 	}
-	g_ms.term = g_ms.saved_term;
-	g_ms.term.c_lflag &= ~(ICANON | ECHO);
-	g_ms.term.c_cc[VMIN] = 1;
-	g_ms.term.c_cc[VTIME] = 0;
-	tcsetattr(STDIN_FILENO, TCSANOW, &g_ms.term);
-	return (UTIL_SUCCESS);
-}
-
-int
-	ft_finalize_term(void)
-{
-	tcsetattr(STDIN_FILENO, TCSANOW, &g_ms.saved_term);
+	if (tcgetattr(STDIN_FILENO, &g_ms.origin_term) != 0)
+	{
+		ft_put_error(strerror(errno));
+		return (UTIL_ERROR);
+	}
+	g_ms.ms_term.c_lflag &= ~(ICANON | ECHO);
+	g_ms.ms_term.c_cc[VMIN] = 1;
+	g_ms.ms_term.c_cc[VTIME] = 0;
 	return (UTIL_SUCCESS);
 }

--- a/srcs/termcaps/init_term.c
+++ b/srcs/termcaps/init_term.c
@@ -1,0 +1,34 @@
+#include "minishell_sikeda.h"
+
+int
+	ft_init_term(void)
+{
+	char	*term_name;
+
+	term_name = getenv("TERM");
+	if (!term_name)
+		term_name = "xterm-256color";
+	if (tgetent(NULL, term_name) <= 0)
+	{
+		ft_put_error("Cannot find terminfo entry.");
+		return (UTIL_ERROR);
+	}
+	if (tcgetattr(STDIN_FILENO, &g_ms.term) != 0)
+	{
+		ft_put_error(strerror(errno));
+		return (UTIL_ERROR);
+	}
+	g_ms.term = g_ms.saved_term;
+	g_ms.term.c_lflag &= ~(ICANON | ECHO);
+	g_ms.term.c_cc[VMIN] = 1;
+	g_ms.term.c_cc[VTIME] = 0;
+	tcsetattr(STDIN_FILENO, TCSANOW, &g_ms.term);
+	return (UTIL_SUCCESS);
+}
+
+int
+	ft_finalize_term(void)
+{
+	tcsetattr(STDIN_FILENO, TCSANOW, &g_ms.saved_term);
+	return (UTIL_SUCCESS);
+}


### PR DESCRIPTION
# 概要
issue #124 termcapを使用した入力受付の基本実装

# 受入条件
内容確認、動作確認

# コメント
- 「make termtest」した後に、「./term.out  」で実行できます。
- できることは以下になります
  - 左右の矢印で辺な文字が出ることなくカーソル移動ができる
  - 上下の矢印で辺な文字が出ない
  - ft_isprintの範囲の文字が画面に表示される
  - 改行で改行される（lineを作ったりプロンプト出したりは未実装です）
  - その行で何も入力していないときに「Ctrl+d」でminishellが終了する
- その他機能は今後追加していきます。

close #124 