### PR TITLE
fix #129 Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,34 +3,35 @@ NAME		:= minishell
 UTILDIR		:= ./srcs/utils/
 TERMDIR		:= ./srcs/termcaps/
 
-SRCS		:=
-SRCS		+= srcs/cd.c srcs/cd_error.c srcs/cd_path_utils.c srcs/cd_fullpath.c \
+SRCS		:= srcs/cd.c srcs/cd_error.c srcs/cd_path_utils.c srcs/cd_fullpath.c \
 				srcs/echo.c srcs/pwd.c srcs/exit.c \
 				srcs/env.c srcs/unset.c \
 				srcs/export.c srcs/export_print.c srcs/export_setenv.c \
 				srcs/init_env.c srcs/env_utils.c srcs/env_utils2.c \
 				srcs/env_sort.c srcs/env_copy.c \
+				srcs/get_next_line.c srcs/make_token.c srcs/make_command.c srcs/expand_env.c \
+				srcs/handle_signal.c \
 				$(UTILDIR)command_utils.c $(UTILDIR)command_errors.c $(UTILDIR)minishell_errors.c \
-				$(UTILDIR)tlist_utils.c $(UTILDIR)split_utils.c $(UTILDIR)utils.c
-OBJS		= $(SRCS:.c=.o)
+				$(UTILDIR)tlist_utils.c $(UTILDIR)split_utils.c $(UTILDIR)utils_tnishina.c $(UTILDIR)utils.c
+SRCS_PRODUCTION	:= $(SRCS)
+SRCS_PRODUCTION	+= srcs/minishell.c srcs/set_redirection.c
+OBJS_PRODUCTION	:= $(SRCS_PRODUCTION:.c=.o)
 
-SRCS_BUITINTEST	:= $(SRCS)
-SRCS_BUITINTEST	+= test/test_builtin.c test/test_init.c test/test_exec.c test/test_launch.c test/test_cd.c
-OBJS_BUITINTEST	= $(SRCS_BUITINTEST:.c=.o)
+SRCS_BUILTINTEST	:= $(SRCS)
+SRCS_BUILTINTEST	+= test/test_builtin.c test/test_init.c test/test_exec.c test/test_launch.c test/test_cd.c
 
 SRCS_TERMTEST	:= $(SRCS)
-SRCS_TERMTEST	+= $(TERMDIR)init_term.c
-SRCS_TERMTEST	+= srcs/minishell_term.c srcs/get_next_line.c srcs/make_token.c srcs/make_command.c srcs/expand_env.c
-OBJS_TERMTEST	= $(SRCS_TERMTEST:.c=.o)
+SRCS_TERMTEST	+= $(TERMDIR)init_term.c srcs/minishell_term.c
 
 INCLUDE		:= -I./includes/ -I./libft/ -I./test/
 
 LIBDIR		:= ./libft
 LIBPATH		:= $(LIBDIR)/libft.a
+LFLAGS		:= -L${LIBDIR} -lft -lcurses
 
 CC			:= gcc
-CFLAGS		:= -Wall -Wextra -Werror -lcurses
-# DEBUG		:= -g -fsanitize=address -lcurses
+CFLAGS		:= -Wall -Wextra -Werror
+# DEBUG		:= -g -fsanitize=address
 DEBUG		:=
 
 RM			:= rm -f
@@ -41,36 +42,35 @@ C_GREEN		:= "\x1b[32m"
 
 all:		$(NAME)
 
-$(NAME):	$(OBJS) $(LIBPATH)
-			$(CC) $(CFLAGS) $(OBJ) $(DEBUG) $(LIBPATH) -o $(NAME)
+$(NAME):	$(OBJS_PRODUCTION) $(LIBPATH)
+			$(CC) $(CFLAGS) $(OBJS_PRODUCTION) $(DEBUG) $(LFLAGS) -o $(NAME)
 			@echo $(C_GREEN)"=== Make Done ==="
 
 btest:		$(LIBPATH)
-			$(CC) $(CFLAGS) $(SRCS_BUITINTEST) $(DEBUG) $(INCLUDE) $(LIBPATH) -D TEST -o builtin.out
+			$(CC) $(CFLAGS) $(SRCS_BUILTINTEST) $(DEBUG) $(INCLUDE) $(LFLAGS) -D TEST -o builtin.out
 			@echo $(C_GREEN)"=== Make Done ==="
 
 bltest:		$(LIBPATH)
-			$(CC) $(CFLAGS) $(SRCS_BUITINTEST) $(DEBUG) $(INCLUDE) $(LIBPATH) -D CDTEST -D LEAKS -o builtin.out
+			$(CC) $(CFLAGS) $(SRCS_BUILTINTEST) $(DEBUG) $(INCLUDE) $(LFLAGS) -D CDTEST -D LEAKS -o builtin.out
 			@echo $(C_GREEN)"=== Make Done ==="
 
 cdtest:		$(LIBPATH)
-			$(CC) $(CFLAGS) $(SRCS_BUITINTEST) $(DEBUG) $(INCLUDE) $(LIBPATH) -D CDTEST -o builtin.out
+			$(CC) $(CFLAGS) $(SRCS_BUILTINTEST) $(DEBUG) $(INCLUDE) $(LFLAGS) -D CDTEST -o builtin.out
 			@echo $(C_GREEN)"=== Make Done ==="
 
 cdltest:	$(LIBPATH)
-			$(CC) $(CFLAGS) $(SRCS_BUITINTEST) $(DEBUG) $(INCLUDE) $(LIBPATH) -D CDTEST -D LEAKS -o builtin.out
+			$(CC) $(CFLAGS) $(SRCS_BUILTINTEST) $(DEBUG) $(INCLUDE) $(LFLAGS) -D CDTEST -D LEAKS -o builtin.out
 			@echo $(C_GREEN)"=== Make Done ==="
 
 termtest:	$(LIBPATH)
-			$(CC) $(CFLAGS) $(SRCS_TERMTEST) $(DEBUG) $(INCLUDE) $(LIBPATH) -D TEST -o term.out
+			$(CC) $(CFLAGS) $(SRCS_TERMTEST) $(DEBUG) $(INCLUDE) $(LFLAGS) -D TEST -o term.out
 			@echo $(C_GREEN)"=== Make Done ==="
 
 $(LIBPATH):
-			$(MAKE) bonus -C $(LIBDIR)
+			$(MAKE) -C $(LIBDIR)
 
 clean:
-			$(RM) $(OBJS)
-			$(RM) $(OBJS_BUITINTEST)
+			$(RM) $(OBJS_PRODUCTION)
 			$(MAKE) clean -C $(LIBDIR)
 
 fclean:		clean

--- a/libft/Makefile
+++ b/libft/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: tnishina <tnishina@student.42tokyo.jp>     +#+  +:+       +#+         #
+#    By: sikeda <sikeda@student.42tokyo.jp>         +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2020/11/03 20:47:42 by tnishina          #+#    #+#              #
-#    Updated: 2020/11/14 16:05:05 by tnishina         ###   ########.fr        #
+#    Updated: 2021/05/01 23:41:31 by sikeda           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -36,10 +36,11 @@ ARFLAGS = rc
 
 RM = rm -f
 
-all:			$(NAME)
+all:		$(NAME)
 
-$(NAME):		$(OBJS)
-	$(AR) $(ARFLAGS) $(NAME) $(OBJS)
+# Bonus rule applied
+$(NAME):	$(OBJS) $(OBJS_BONUS)
+	$(AR) $(ARFLAGS) $(NAME) $(OBJS) $(OBJS_BONUS)
 
 bonus:		$(OBJS) $(OBJS_BONUS)
 	$(AR) $(ARFLAGS) $(NAME) $(OBJS) $(OBJS_BONUS)


### PR DESCRIPTION
# 概要
issue #129 Makefile typo修正、細かい修正

# 受入条件
内容確認、make動作確認

# コメント
- SRCS_BUITINTESTにLが抜けていたのを修正しました
- `make`コマンドが通るようにしました
- `make`コマンドと既存のテストが共存できるように、`make`で使用しテストに干渉させたくないファイルを`SRCS_PRODUCTION `, `OBJS_PRODUCTION`にまとめました（main等の関数のバッティングがあるため）
- ライブラリ用フラグ`LFLAGS`を足しました
- Libftのt_listを使用するので`make bonus`を使用していますが、これは毎回リリンクしてしまうので、通常の`make`でボーナスの内容が行われるようにしました

close #129