### PR TITLE
fix #133 input interruption

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ NAME		:= minishell
 UTILDIR		:= ./srcs/utils/
 TERMDIR		:= ./srcs/termcaps/
 
-SRCS		:= srcs/cd.c srcs/cd_error.c srcs/cd_path_utils.c srcs/cd_fullpath.c \
+SRCS		:= srcs/init_minishell.c \
+				srcs/cd.c srcs/cd_error.c srcs/cd_path_utils.c srcs/cd_fullpath.c \
 				srcs/echo.c srcs/pwd.c srcs/exit.c \
 				srcs/env.c srcs/unset.c \
 				srcs/export.c srcs/export_print.c srcs/export_setenv.c \

--- a/includes/minishell_sikeda.h
+++ b/includes/minishell_sikeda.h
@@ -48,12 +48,16 @@ typedef struct s_minishell
 {
 	struct termios	ms_term;
 	struct termios	origin_term;
+	t_bool			interrupted;
 }	t_minishell;
 
 t_minishell	g_ms;
 int			g_status;
 char		*g_pwd;
 t_list		*g_env;
+
+/* init_minishell.c */
+int		init_minishell(void);
 
 /* utils/minishell_errors.c */
 void	ft_put_error(char *msg);

--- a/srcs/handle_signal.c
+++ b/srcs/handle_signal.c
@@ -7,6 +7,7 @@ void
 {
 	ft_putstr_fd("\n", STDERR_FILENO);
 	ft_putstr_fd(PROMPT, STDERR_FILENO);
+	g_ms.interrupted = TRUE;
 	g_status = 1;
 }
 

--- a/srcs/init_minishell.c
+++ b/srcs/init_minishell.c
@@ -1,0 +1,22 @@
+#include "minishell_sikeda.h"
+
+int
+	init_minishell(void)
+{
+	if (ft_init_env() == STOP)
+		return (UTIL_ERROR);
+	if (ft_init_pwd() == STOP)
+	{
+		ft_lstclear(&g_env, free);
+		return (UTIL_ERROR);
+	}
+	if (ft_init_term() == UTIL_ERROR)
+	{
+		printf("error\n");
+		ft_lstclear(&g_env, free);
+		ft_free(&g_pwd);
+		return (UTIL_ERROR);
+	}
+	g_ms.interrupted = FALSE;
+	return (UTIL_SUCCESS);
+}


### PR DESCRIPTION
# 概要
issue #133 コマンド入力中のCtrl+C対応

# 受入条件
内容確認、動作確認

# コメント
- 「make termtest」後に「./term.out」で起動します
- コマンド入力中にCtrl+Cをした後にエンターを押すと入力中だったものが実行されるという現象があったので修正しました
- これでシグナルは全て対応できていると思います、ご確認ください

close #133 