### PR TITLE
fix #116 #125 #128 error cases

### DIFF
--- a/includes/minishell_tnishina.h
+++ b/includes/minishell_tnishina.h
@@ -54,6 +54,7 @@ typedef enum e_status
 {
 	FAILED,
 	ENV_DELETED,
+	TOKEN_DELETED,
 	COMPLETED
 }	t_status;
 
@@ -66,6 +67,7 @@ typedef struct			s_command
 {
 	t_list				*args;
 	char				*op;
+	t_list				*redirects;
 	pid_t				pid;
 	struct s_command	*next;
 }						t_command;
@@ -73,24 +75,40 @@ typedef struct			s_command
 int			get_next_line(int fd, char **line);
 void		ft_free_str(char **str);
 int			ft_make_token(t_list **tokens, char *line, t_bool(*f)(char*, int, int*));
-int			ft_make_command(t_command **commands, t_list *tokens);
-void		ft_clear_commands(t_command **c);
-int			ft_expand_env_var(t_command *c);
 t_bool		ft_is_delimiter_or_quote(char *l, int i, int *fl);
 t_bool		ft_is_delimiter(char c);
 void		ft_put_fderror(int fd_from);
 
+/* expand_env.c */
+int			ft_expand_env_var(t_command *c);
+t_bool		ft_remove_char(char **s, int i);
+
 /* utils_tnishina.c */
 char		**ft_convert_list(t_list *l);
 void		ft_clear_argv(char ***argv);
+int			ft_isover_intrange(char *s);
 
 /* handle_signal.c */
 void		ft_sig_prior(void);
 void		ft_sig_post(void);
 
 /* set_redirection.c */
-t_bool		ft_set_redirection(t_list **args);
+t_bool		ft_set_redirection(t_list *rd);
 void		ft_save_fds(int std_fds[3]);
 void		ft_restore_fds(int std_fds[3]);
+
+/* add_space.c */
+int			ft_add_space(char **l);
+
+/* make_command.c */
+t_bool		ft_is_redirect(char *arg);
+int			ft_make_command(t_command **commands, t_list *tokens);
+void		ft_clear_commands(t_command **c);
+
+/* extract_redirect.c */
+void		ft_extract_redirect(t_command *c);
+
+/* remove_escape.c */
+int			ft_remove_escape(t_list *lst);
 
 #endif

--- a/multipipetest.sh
+++ b/multipipetest.sh
@@ -14,4 +14,339 @@ gcc -g -Wall -Wextra -Werror -I./includes -I./libft \
 	srcs/utils/command_errors.c srcs/utils/utils_tnishina.c srcs/minishell.c\
 	srcs/make_command.c srcs/make_token.c srcs/get_next_line.c srcs/expand_env.c \
     srcs/utils/tlist_utils.c srcs/utils/split_utils.c srcs/set_redirection.c\
+    srcs/handle_signal.c srcs/add_space.c srcs/extract_redirect.c srcs/remove_escape.c\
     -Llibft -lft -o multipipe.out #-D LEAKS
+
+YELLOW=$(printf '\033[33m')
+CYAN=$(printf '\033[36m')
+RESET=$(printf '\033[0m')
+
+printf "\n${CYAN}%s${RESET}\n\n" "***Test starts***"
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo \$?"
+echo "echo \$?" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo \$?"
+echo "echo \$?" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo \$PWD?"
+echo "echo \$PWD?" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo \$PWD?"
+echo "echo \$PWD?" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo \$?PWD"
+echo "echo \$?PWD" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo \$?PWD"
+echo "echo \$?PWD" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo \$?."
+echo "echo \$?." | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo \$?."
+echo "echo \$?." | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo \$.?"
+echo "echo \$.?" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo \$.?"
+echo "echo \$.?" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo \$?\$?"
+echo "echo \$?\$?" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo \$?\$?"
+echo "echo \$?\$?" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo \$USER\$?"
+echo "echo \$USER\$?" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo \$USER\$?"
+echo "echo \$USER\$?" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo \"\"\$?\"\""
+echo "echo \"\"\$?\"\"" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo \"\"\$?\"\""
+echo "echo \"\"\$?\"\"" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo \"\$?\""
+echo "echo \"\$?\"" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo \"\$?\""
+echo "echo \"\$?\"" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo \\ "
+echo "echo \\ " | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo \\ "
+echo "echo \\ " | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo hello 2147483647> file"
+echo "echo hello 2147483647> file" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo hello 2147483647> file"
+echo "echo hello 2147483647> file" | bash
+echo
+
+#未対応です
+printf "\n${CYAN}%s${RESET}\n\n" "未対応です"
+printf "${YELLOW}%s${RESET}\n\n" "[mini] whereis ls | cat -e | cat -e > test"
+echo "whereis ls | cat -e | cat -e > test" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] whereis ls | cat -e | cat -e > test"
+echo "whereis ls | cat -e | cat -e > test" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo \">\""
+echo "echo \">\"" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo \">\""
+echo "echo \">\"" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] touch \">\""
+echo "touch \">\"" | ./multipipe.out
+rm ">"
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] touch \">\""
+echo "touch \">\"" | bash
+rm ">"
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo something > > file"
+echo "echo something > > file" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo something > > file"
+echo "echo something > > file" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] > file cd wtf ; cat file"
+echo "> file cd wtf ; cat file" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] > file cd wtf ; cat file"
+echo "> file cd wtf ; cat file" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] cat < Makefile > file"
+echo "cat < Makefile > file" | ./multipipe.out
+rm file
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] cat < Makefile > file"
+echo "cat < Makefile > file" | bash
+rm file
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] export TEST=hello; echo \$TEST"
+echo "export TEST=hello; echo \$TEST" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] export TEST=hello; echo \$TEST"
+echo "export TEST=hello; echo \$TEST" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo $"
+echo "echo $" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo $"
+echo "echo $" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo \"$\""
+echo "echo \"$\"" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo \"$\""
+echo "echo \"$\"" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo \\$"
+echo "echo \\$" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo \\$"
+echo "echo \\$" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo \"\\$\""
+echo "echo \"\\$\"" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo \"\\$\""
+echo "echo \"\\$\"" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo \\\"\\\""
+echo "echo \\\"\\\"" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo \\\"\\\""
+echo "echo \\\"\\\"" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo test >"
+echo "echo test >" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo test >"
+echo "echo test >" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo test > >"
+echo "echo test > >" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo test > >"
+echo "echo test > >" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo test > >>"
+echo "echo test > >>" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo test > >>"
+echo "echo test > >>" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo test <"
+echo "echo test <" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo test <"
+echo "echo test <" | bash
+echo
+
+printf "\n${CYAN}%s${RESET}\n\n" "私達の実装だと<<をカバーしていないので、エラーメッセージも違っています"
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo test < <<"
+echo "echo test < <<" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo test < <<"
+echo "echo test < <<" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo 1 >file; cat file"
+echo "echo 1 >file; cat file" | ./multipipe.out
+echo
+rm file
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo 1 >file; cat file"
+echo "echo 1 >file; cat file" | bash
+echo
+rm file
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo 2 >file"
+echo "echo 2 >file" | ./multipipe.out
+echo
+rm file
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo 2 >file"
+echo "echo 2 >file" | bash
+echo
+rm file
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo 256 >file"
+echo "echo 256 >file" | ./multipipe.out
+echo
+rm file
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo 256 >file"
+echo "echo 256 >file" | bash
+echo
+rm file
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo 2>file"
+echo "echo 2>file" | ./multipipe.out
+echo
+rm file
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo 2>file"
+echo "echo 2>file" | bash
+echo
+rm file
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo 2 \'1\'>file; cat file"
+echo "echo 2 \'1\'>file; cat file" | ./multipipe.out
+echo
+rm file
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo 2 \'1\'>file; cat file"
+echo "echo 2 \'1\'>file; cat file" | bash
+echo
+rm file
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] 1>file echo 1"
+echo "1>file echo 1" | ./multipipe.out
+echo
+rm file
+printf "${YELLOW}%s${RESET}\n\n" "[bash] 1>file echo 1"
+echo "1>file echo 1" | bash
+echo
+rm file
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] touch file; chmod 0 file; echo hello >file"
+echo "touch file; chmod 0 file; echo hello >file" | ./multipipe.out
+echo
+rm -f file
+printf "${YELLOW}%s${RESET}\n\n" "[bash] touch file; chmod 0 file; echo hello >file"
+echo "touch file; chmod 0 file; echo hello >file" | bash
+echo
+rm -rf file
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo hello > ./"
+echo "echo hello > ./" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo hello > ./"
+echo "echo hello > ./" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo hello >>>> file"
+echo "echo hello >>>> file" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo hello >>>> file"
+echo "echo hello >>>> file" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo hello \">\""
+echo "echo hello \">\"" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo hello \">\""
+echo "echo hello \">\"" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo hi > file1; cat < file1 > file2; diff file1 file2"
+echo "echo hi > file1; cat < file1 > file2; diff file1 file2" | ./multipipe.out
+echo
+rm file1 file2
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo hi > file1; cat < file1 > file2; diff file1 file2"
+echo "echo hi > file1; cat < file1 > file2; diff file1 file2" | bash
+echo
+rm file1 file2
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] export ZERO=0; echo \$ZERO> file1; cat file1"
+echo "export ZERO=0; echo \$ZERO> file1; cat file1" | ./multipipe.out
+echo
+rm file1
+printf "${YELLOW}%s${RESET}\n\n" "[bash] export ZERO=0; echo \$ZERO> file1; cat file1"
+echo "export ZERO=0; echo \$ZERO> file1; cat file1" | bash
+echo
+rm file1
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo hello >>>file"
+echo "echo hello >>>file" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo hello >>>file"
+echo "echo hello >>>file" | bash
+echo
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo hello > 1; cat 1"
+echo "echo hello > 1; cat 1" | ./multipipe.out
+echo
+rm "1"
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo hello > 1; cat 1"
+echo "echo hello > 1; cat 1" | bash
+echo
+rm "1"
+
+printf "${YELLOW}%s${RESET}\n\n" "[mini] echo hello \">\""
+echo "echo hello \">\"" | ./multipipe.out
+echo
+printf "${YELLOW}%s${RESET}\n\n" "[bash] echo hello \">\""
+echo "echo hello \">\"" | bash
+echo

--- a/srcs/add_space.c
+++ b/srcs/add_space.c
@@ -1,0 +1,59 @@
+#include "minishell_tnishina.h"
+#include "minishell_sikeda.h"
+#include "libft.h"
+
+t_bool
+	add_space_after_redirect(char **l, int *i)
+{
+	char	*tmp[2];
+	char	*front;
+	char	*back;
+	t_bool	res;
+
+	res = TRUE;
+	tmp[0] = *l;
+	front = ft_substr(*l, 0, *i + 1);
+	back = ft_strdup(*l + *i + 1);
+	tmp[1] = ft_strjoin(front, " ");
+	*l = ft_strjoin(tmp[1], back);
+	if (!front || !back || !tmp[1] || !(*l))
+		res = FALSE;
+	ft_free(&tmp[0]);
+	ft_free(&tmp[1]);
+	ft_free(&front);
+	ft_free(&back);
+	return (res);
+}
+
+/*
+** f[2] is a flag array. Each of elements is a flag for the purpose explained
+** below.
+**
+** f[0]: a flag for single quotations (')
+** f[1]: a flag for double quotations (")
+*/
+
+int
+	ft_add_space(char **l)
+{
+	int		i;
+	int		fl[2];
+
+	i = 0;
+	ft_bzero(fl, sizeof(fl));
+	while ((*l)[i])
+	{
+		if ((*l)[i] == '\'')
+			fl[0] = !fl[0];
+		else if ((*l)[i] == '\"')
+			fl[1] = !fl[1];
+		if (!fl[0] && !fl[1]
+			&& ((*l)[i] == '<' || ((*l)[i] == '>' && (*l)[i + 1] != '>')))
+		{
+			if (!add_space_after_redirect(l, &i))
+			 return (STOP);
+		}
+		i++;
+	}
+	return (KEEP_RUNNING);
+}

--- a/srcs/extract_redirect.c
+++ b/srcs/extract_redirect.c
@@ -1,0 +1,42 @@
+#include "minishell_sikeda.h"
+#include "minishell_tnishina.h"
+#include "libft.h"
+
+static void
+	update_redirects(t_command *c, t_list **current, t_list *prev)
+{
+	if (prev)
+		prev->next = (*current)->next->next;
+	else
+		c->args = (*current)->next->next;
+	(*current)->next->next = NULL;
+	ft_lstadd_back(&(c->redirects), *current);
+	if (prev)
+		(*current) = prev->next;
+	else
+		(*current) = c->args;
+}
+
+void
+	ft_extract_redirect(t_command *c)
+{
+	t_list	*current;
+	t_list	*prev;
+
+	while (c)
+	{
+		current = c->args;
+		prev = NULL;
+		while (current)
+		{
+			if (ft_is_redirect((char *)(current->content)))
+				update_redirects(c, &current, prev);
+			else
+			{
+				prev = current;
+				current = current->next;
+			}
+		}
+		c = c->next;
+	}
+}

--- a/srcs/make_token.c
+++ b/srcs/make_token.c
@@ -23,11 +23,14 @@ t_bool
 t_bool
 	ft_is_delimiter_or_quote(char *l, int i, int *fl)
 {
-	if ((!fl[0] && !fl[1] && (l[i] == '\0' || l[i] == ' ' || l[i] == '|' || l[i] == ';' || l[i] == '<' ||
-		(i && l[i] == '>') || (l[i] == '>' && l[i + 1] != '>'))) ||
-		((!i || l[i - 1] != '\\') && l[i] == '\'' && fl[0] && ft_is_delimiter(l[i + 1])) ||
-		((!i || l[i - 1] != '\\') && l[i] == '\"' && fl[1] && ft_is_delimiter(l[i + 1])) ||
-		((fl[0] || fl[1]) && !l[i]))
+	if ((!fl[0] && !fl[1] && (!i || l[i - 1] != '\\')
+		&& (l[i] == '\0' || (l[i] == ' ' || l[i] == '|' || l[i] == ';')
+		|| (!fl[3] && l[i] == '<') || (!fl[3] && i && l[i] == '>')
+		|| (!fl[3] && l[i] == '>' && l[i + 1] != '>')
+		|| (fl[2] && l[i] == '>')))
+		|| ((!i || l[i - 1] != '\\') && l[i] == '\'' && fl[0] && ft_is_delimiter(l[i + 1]))
+		|| ((!i || l[i - 1] != '\\') && l[i] == '\"' && fl[1] && ft_is_delimiter(l[i + 1]))
+		|| ((fl[0] || fl[1]) && !l[i]))
 		return (TRUE);
 	else
 	{
@@ -41,6 +44,10 @@ t_bool
 			fl[1] = 0;
 		else if (l[i] == '>' && l[i + 1] == '>')
 			fl[2] = 1;
+		else if (!i && ft_isdigit(l[i]))
+			fl[3] = 1;
+		else if (fl[3] && !ft_isdigit(l[i]))
+			fl[3] = 0;
 		return (FALSE);
 	}
 }
@@ -55,12 +62,13 @@ static int
 }
 
 /*
-** f[3] is a flag array. Each of elements is a flag for the purpose explained
+** f[4] is a flag array. Each of elements is a flag for the purpose explained
 ** below.
 **
 ** f[0]: a flag for single quotations (')
 ** f[1]: a flag for double quotations (")
 ** f[2]: a flag for double arrows (>>)
+** f[3]: a flag for file descriptor before arrow (1>, 2>, etc.)
 */
 
 int
@@ -69,7 +77,7 @@ int
 	t_list	*n;
 	int		i;
 	char	*cpy;
-	int		fl[3];
+	int		fl[4];
 
 	*tokens = NULL;
 	if (!l)
@@ -77,7 +85,7 @@ int
 	while (*l)
 	{
 		i = 0;
-		ft_memset(fl, 0, sizeof(int) * 3);
+		ft_bzero(fl, sizeof(fl));
 		while (*l == ' ')
 			l++;
 		while (!(f(l, i, fl)))

--- a/srcs/remove_escape.c
+++ b/srcs/remove_escape.c
@@ -1,0 +1,35 @@
+#include "minishell_sikeda.h"
+#include "minishell_tnishina.h"
+#include "libft.h"
+
+static int
+	del_escape(char **s)
+{
+	int		i;
+
+	i = 0;
+
+	while ((*s)[i])
+	{
+		if ((*s)[i] == '\\' && (*s)[i + 1] != '\\')
+		{
+			if (!(ft_remove_char(s, i)))
+				return (FALSE);
+		}
+		else
+			i++;
+	}
+	return (TRUE);
+}
+
+int
+	ft_remove_escape(t_list *lst)
+{
+	while (lst)
+	{
+		if (del_escape((char **)&(lst->content)) == FAILED)
+			return (FAILED);
+		lst = lst->next;
+	}
+	return (COMPLETED);
+}

--- a/srcs/set_redirection.c
+++ b/srcs/set_redirection.c
@@ -21,142 +21,141 @@ void
 	close(std_fds[2]);
 }
 
-static t_bool
-	is_redirect(char *str)
+static int
+	get_fd(char *arg)
 {
-	if (!ft_strncmp(str, REDIRECT_IN, ft_strlen(REDIRECT_IN))
-	|| !ft_strncmp(str, REDIRECT_OUT, ft_strlen(REDIRECT_OUT))
-	|| !ft_strncmp(str, APPEND_REDIRECT_OUT, ft_strlen(APPEND_REDIRECT_OUT)))
-		return (TRUE);
+	int		len;
+	char	*fd_str;
+	int		fd_num;
+
+	if (!arg)
+		return (-2);
+	len = ft_strlen(arg);
+	if (len == 1)
+		return (-1);
+	else if (arg[0] == '>')
+		return (-1);
+	else
+	{
+		if (ft_isdigit(arg[len - 2]))
+			fd_str = ft_substr(arg, 0, len - 1);
+		else
+			fd_str = ft_substr(arg, 0, len - 2);
+		if (ft_isover_intrange(fd_str) != 0)
+			fd_num = -3;
+		else
+			fd_num = ft_atoi(fd_str);
+		ft_free(&fd_str);
+		return (fd_num);
+	}
+}
+
+static char
+	*get_op(char *arg)
+{
+	if (!arg)
+		return (NULL);
+	while (ft_isdigit(*arg))
+		arg++;
+	return (ft_strdup(arg));
+}
+
+static t_bool
+	append_redirect_out(int fd_from, char *path)
+{
+	int	fd_to;
+
+	fd_to = open(path, O_WRONLY | O_CREAT | O_APPEND, 0666);
+	if (fd_to < 0)
+	{
+		ft_put_cmderror(path, strerror(errno));
+		g_status = 1;
+		return (FALSE);
+	}
+	if (fd_from == -1)
+		fd_from = STDOUT_FILENO;
+	dup2(fd_to, fd_from);
+	close(fd_to);
+	return (TRUE);
+}
+
+static t_bool
+	redirect_out(int fd_from, char *path)
+{
+	int	fd_to;
+
+	fd_to = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+	if (fd_to < 0)
+	{
+		ft_put_cmderror(path, strerror(errno));
+		g_status = 1;
+		return (FALSE);
+	}
+	if (fd_from == -1)
+		fd_from = STDOUT_FILENO;
+	dup2(fd_to, fd_from);
+	close(fd_to);
+	return (TRUE);
+}
+
+static t_bool
+	redirect_in(int fd_from, char *path)
+{
+	int	fd_to;
+
+	fd_to = open(path, O_RDONLY);
+	if (fd_to < 0)
+	{
+		ft_put_cmderror(path, strerror(errno));
+		g_status = 1;
+		return (FALSE);
+	}
+	if (fd_from == -1)
+		fd_from = STDIN_FILENO;
+	dup2(fd_to, fd_from);
+	close(fd_to);
+	return (TRUE);
+}
+
+static t_bool
+	execute_redirection(int fd_from, char *redirect_op, char *path)
+{
+	if (!(ft_strcmp(redirect_op, APPEND_REDIRECT_OUT)))
+		return (append_redirect_out(fd_from, path));
+	else if (!(ft_strcmp(redirect_op, REDIRECT_OUT)))
+		return (redirect_out(fd_from, path));
+	else if (!(ft_strcmp(redirect_op, REDIRECT_IN)))
+		return (redirect_in(fd_from, path));
 	else
 		return (FALSE);
 }
 
 t_bool
-	ft_set_redirection(t_list **args)
+	ft_set_redirection(t_list *rd)
 {
-	t_list	*head;
-	t_list	*prev;
 	int		fd_from;
-	int		fd_to;
 	char	*path;
 	char	*redirect_op;
+	int		res;
 
-	prev = NULL;
-	head = *args;
-	fd_from = -1;
-	redirect_op = NULL;
-	path = NULL;
-	while (*args)
+	res = TRUE;
+	while (rd && res)
 	{
-		if (ft_isdigit(((char*)((*args)->content))[0]) && ft_isnumeric((char*)((*args)->content)) && is_redirect((char*)((*args)->next->content)))
+		fd_from = get_fd((char *)(rd->content));
+		if (fd_from == -3 || FD_MAX < fd_from)
+			ft_put_fderror(fd_from);
+		redirect_op = get_op((char *)(rd->content));
+		path = ft_strdup((char *)(rd->next->content));
+		if (fd_from <= -2 || FD_MAX < fd_from || !redirect_op || !path)
 		{
-			fd_from = ft_atoi((char*)((*args)->content));
-			if (fd_from < 0 || FD_MAX < fd_from)
-			{
-				ft_put_fderror(fd_from);
-				g_status = 1;
-				return (FALSE);
-			}
-			redirect_op = ft_strdup((char*)((*args)->next->content));
-			path = ft_strdup((char*)((*args)->next->next->content));
-			if (!redirect_op || !path)
-			{
-				FREE(redirect_op);
-				FREE(path);
-				g_status = 1;
-				return (FALSE);
-			}
-			if (prev)
-				prev->next = (*args)->next->next->next;
-			else
-				head = (*args)->next->next->next;
-			ft_lstdelone((*args)->next->next, free);
-			ft_lstdelone((*args)->next, free);
-			ft_lstdelone((*args), free);
-			if (prev)
-				*args = prev->next;
-			else
-				*args = head;
+			g_status = 1;
+			return (FALSE);
 		}
-		else if (is_redirect((char*)((*args)->content)))
-		{
-			redirect_op = ft_strdup((char*)((*args)->content));
-			path = ft_strdup((char*)((*args)->next->content));
-			if (!redirect_op || !path)
-			{
-				FREE(redirect_op);
-				FREE(path);
-				g_status = 1;
-				return (FALSE);
-			}
-			if (prev)
-				prev->next = (*args)->next->next;
-			else
-				head = (*args)->next->next;
-			ft_lstdelone((*args)->next, free);
-			ft_lstdelone((*args), free);
-			if (prev)
-				*args = prev->next;
-			else
-				*args = head;
-		}
-		if (!redirect_op)
-		{
-			prev = *args;
-			*args = (*args)->next;
-		}
-		else if (!(ft_strcmp(redirect_op, APPEND_REDIRECT_OUT)))
-		{
-			fd_to = open(path, O_WRONLY | O_CREAT | O_APPEND, 0666);
-			if (fd_to < 0)
-			{
-				ft_put_cmderror(path, strerror(errno));
-				g_status = 1;
-				FREE(redirect_op);
-				FREE(path);
-				return (FALSE);
-			}
-			if (fd_from == -1)
-				fd_from = STDOUT_FILENO;
-			dup2(fd_to, fd_from);
-			close(fd_to);
-		}
-		else if (!(ft_strcmp(redirect_op, REDIRECT_OUT)))
-		{
-			fd_to = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0666);
-			if (fd_to < 0)
-			{
-				ft_put_cmderror(path, strerror(errno));
-				g_status = 1;
-				FREE(redirect_op);
-				FREE(path);
-				return (FALSE);
-			}
-			if (fd_from == -1)
-				fd_from = STDOUT_FILENO;
-			dup2(fd_to, fd_from);
-			close(fd_to);
-		}
-		else if (!(ft_strcmp(redirect_op, REDIRECT_IN)))
-		{
-			fd_to = open(path, O_RDONLY);
-			if (fd_to < 0)
-			{
-				ft_put_cmderror(path, strerror(errno));
-				g_status = 1;
-				FREE(redirect_op);
-				FREE(path);
-				return (FALSE);
-			}
-			if (fd_from == -1)
-				fd_from = STDIN_FILENO;
-			dup2(fd_to, fd_from);
-			close(fd_to);
-		}
-		FREE(redirect_op);
-		FREE(path);
+		if (!execute_redirection(fd_from, redirect_op, path))
+			res = FALSE;
+		ft_free(&redirect_op);
+		ft_free(&path);
+		rd = rd->next->next;
 	}
-	*args = head;
-	return (TRUE);
+	return (res);
 }

--- a/srcs/utils/minishell_errors.c
+++ b/srcs/utils/minishell_errors.c
@@ -33,7 +33,7 @@ void
 	fd = STDERR_FILENO;
 	ft_putstr_fd(PRG_NAME, fd);
 	ft_putstr_fd(": ", fd);
-	if (fd_from < 0)
+	if (fd_from == -3)
 		ft_putstr_fd(FD_OOR_MSG, fd);
 	else
 		ft_putnbr_fd(fd_from, fd);

--- a/srcs/utils/utils_tnishina.c
+++ b/srcs/utils/utils_tnishina.c
@@ -46,3 +46,27 @@ void
 	free(head);
 	head = NULL;
 }
+
+int
+	ft_isover_intrange(char *s)
+{
+	uint64_t	num;
+	int			is_minus;
+	while (ft_isspace(*s))
+		s++;
+	if (*s == '-')
+		is_minus = 1;
+	if (*s == '+' || *s == '-')
+		s++;
+	num = 0;
+	while (ft_isdigit(*s))
+	{
+		num = num * 10 + *s - '0';
+		if (is_minus && (int64_t)__INT_MAX__ + 1 < num)
+			return (-1);
+		else if (!is_minus && (uint64_t)__INT_MAX__ < num)
+			return (1);
+		s++;
+	}
+	return (0);
+}


### PR DESCRIPTION
# 概要
#116 #125 #128のエラーケースに対応しました (#138の部分のみ未対応です)

# 受入条件
動作確認、内容確認

# コメント
- `bash multipipetest.sh; ./multipipe.out`で実行可能です
- shell scriptで動かすとminishellの方がexitのコマンドが出てしまっていて、見にくくなってしまっており、すいません

close #116 
close #125 
close #128 