### PR TITLE
fix #136 to delete char when there is multi-line inputs

### DIFF
--- a/includes/minishell_sikeda.h
+++ b/includes/minishell_sikeda.h
@@ -46,6 +46,7 @@ typedef enum e_cmd_signal
 
 typedef struct s_minishell
 {
+	t_terminfo		terminfo;
 	struct termios	ms_term;
 	struct termios	origin_term;
 	t_bool			interrupted;

--- a/includes/termcaps.h
+++ b/includes/termcaps.h
@@ -3,8 +3,10 @@
 
 # include <term.h>
 # include <termios.h>
+# include <sys/ioctl.h>
 
 # define C_EOF 4
+# define C_ESC 27
 # define C_DEL 127
 # define K_UP "\e[A"
 # define K_DOWN "\e[B"
@@ -14,13 +16,39 @@
 # define K_HOME "\e[H"
 # define K_END "\e[F"
 
+typedef struct s_termdef
+{
+	char	*cm;
+	char	*ce;
+	char	*cr;
+}	t_termdef;
+
+typedef struct s_cursor
+{
+	int	row;
+	int	col;
+}	t_cursor;
+
+typedef struct s_terminfo
+{
+	int			maxcol;
+	int			maxrow;
+	t_cursor	start;
+	t_cursor	prev;
+	t_cursor	current;
+	t_termdef	def;
+}	t_terminfo;
+
 /* init_term.c */
 int	ft_init_term(void);
 
 /* edit_term.c */
-int	ft_clear_line(void);
+int	ft_backspace(const char *pre_line, size_t len);
 
 /* term_utils.c */
 int ft_putchar(int c);
+int	ft_get_cursor_position(int *row, int *col);
+int	ft_update_current_position(void);
+int	ft_get_win_size(void);
 
 #endif

--- a/srcs/termcaps/edit_term.c
+++ b/srcs/termcaps/edit_term.c
@@ -1,10 +1,18 @@
 #include "minishell_tnishina.h"
 
 int
-	ft_clear_line(void)
+	ft_backspace(const char *pre_line, size_t len)
 {
-	tputs(tgetstr("dl", 0), 1, ft_putchar);
-	tputs(tgetstr("cr", 0), 1, ft_putchar);
-	ft_putstr_fd(PROMPT, STDOUT_FILENO);
+	int	col;
+	int	row;
+
+	col = g_ms.terminfo.start.col;
+	row = g_ms.terminfo.start.row;
+	tputs(tgoto(g_ms.terminfo.def.cm, col, row), 1, ft_putchar);
+	tputs(g_ms.terminfo.def.ce, 1, ft_putchar);
+	ft_putstr_fd(PROMPT, STDERR_FILENO);
+	write(STDERR_FILENO, pre_line, len);
+	ft_update_current_position();
+	write(1, "\x1b[0J", 4);
 	return (UTIL_SUCCESS);
 }

--- a/srcs/termcaps/init_term.c
+++ b/srcs/termcaps/init_term.c
@@ -1,5 +1,26 @@
 #include "minishell_sikeda.h"
 
+static int
+	get_definition_from_termcap(void)
+{
+	g_ms.terminfo.def.cm = tgetstr("cm", 0);
+	g_ms.terminfo.def.ce = tgetstr("cd", 0);
+	g_ms.terminfo.def.cr = tgetstr("cr", 0);
+	if (!g_ms.terminfo.def.cm
+		|| !g_ms.terminfo.def.ce
+		|| !g_ms.terminfo.def.cr)
+		return (UTIL_ERROR);
+	return (UTIL_SUCCESS);
+}
+
+static void
+	set_settings(void)
+{
+	g_ms.ms_term.c_lflag &= ~(ICANON | ECHO);
+	g_ms.ms_term.c_cc[VMIN] = 1;
+	g_ms.ms_term.c_cc[VTIME] = 0;
+}
+
 int
 	ft_init_term(void)
 {
@@ -13,6 +34,9 @@ int
 		ft_put_error("Cannot find terminfo entry.");
 		return (UTIL_ERROR);
 	}
+	ft_get_win_size();
+	if (get_definition_from_termcap() == UTIL_ERROR)
+		return (UTIL_ERROR);
 	if (tcgetattr(STDIN_FILENO, &g_ms.ms_term) != 0)
 	{
 		ft_put_error(strerror(errno));
@@ -23,8 +47,6 @@ int
 		ft_put_error(strerror(errno));
 		return (UTIL_ERROR);
 	}
-	g_ms.ms_term.c_lflag &= ~(ICANON | ECHO);
-	g_ms.ms_term.c_cc[VMIN] = 1;
-	g_ms.ms_term.c_cc[VTIME] = 0;
+	set_settings();
 	return (UTIL_SUCCESS);
 }

--- a/srcs/termcaps/term_utils.c
+++ b/srcs/termcaps/term_utils.c
@@ -1,6 +1,57 @@
 #include "minishell_sikeda.h"
 
-int ft_putchar(int c)
+int
+	ft_putchar(int c)
 {
 	return (write(1, &c, 1));
+}
+
+/* get cursor position from syntax like "^[[31;12R" */
+int
+	ft_get_cursor_position(int *row, int *col)
+{
+	char			buf[32];
+	unsigned int	i;
+	int				ret;
+
+	i = 0;
+	ret = write(STDOUT_FILENO, "\x1b[6n", 4);
+	if (ret != 4)
+		return (UTIL_ERROR);
+	while (i < sizeof(buf) - 1)
+	{
+		ret = read(STDIN_FILENO, buf + i, 1);
+		if (ret != 1)
+			break ;
+		if (buf[i] == 'R')
+			break ;
+		i++;
+	}
+	buf[i] = '\0';
+	if (buf[0] != C_ESC || buf[1] != '[')
+		return (UTIL_ERROR);
+	*row = ft_atoi(buf + 2) - 1;
+	*col = ft_atoi(ft_strchr(buf + 2, ';') + 1) - 1;
+	return (UTIL_SUCCESS);
+}
+
+int
+	ft_update_current_position(void)
+{
+	g_ms.terminfo.prev.col = g_ms.terminfo.current.col;
+	g_ms.terminfo.prev.row = g_ms.terminfo.current.row;
+	ft_get_cursor_position(
+		&g_ms.terminfo.current.row, &g_ms.terminfo.current.col);
+	return (UTIL_SUCCESS);
+}
+
+int
+	ft_get_win_size(void)
+{
+	struct winsize	ws;
+
+	ioctl(1, TIOCGWINSZ, &ws);
+	g_ms.terminfo.maxcol = ws.ws_col;
+	g_ms.terminfo.maxrow = ws.ws_row;
+	return (UTIL_SUCCESS);
 }


### PR DESCRIPTION
# 概要
issue #136 端末の横幅を超えて入力した後にバックスペースを入力すると表示崩れ

# 受入条件
内容確認、動作確認

# コメント
- 「make termtest」の後に「./term.out」で起動できます
- 端末の横幅を超える複数行の入力があるときにバックスペースによる削除で画面が崩れないようにしました
- 端末の最終行到達後も入力を続けた複数行の入力があるときにバックスペースによる削除で画面が崩れないようにしました

#close #136