### PR TITLE
fix #145 cursor position when input backspace at the begining of the second line

### DIFF
--- a/includes/termcaps.h
+++ b/includes/termcaps.h
@@ -75,8 +75,7 @@ int	ft_input_char(const char *buf, char *pre_line,
 int	ft_get_line(char **line);
 
 /* handle_keys.c */
-int	ft_handle_keys(const char *buf, char *pre_line,
-		size_t *len, size_t *allocated);
+int	ft_handle_keys_loop(char *pre_line, size_t *len);
 
 /* term_utils.c */
 int	ft_putchar(int c);

--- a/srcs/termcaps/edit_term.c
+++ b/srcs/termcaps/edit_term.c
@@ -1,16 +1,27 @@
 #include "minishell_tnishina.h"
 
-int
-	ft_backspace(const char *pre_line, size_t *len)
+static void
+	put_line(const char *pre_line, size_t *len)
 {
 	int	row;
 
-	(*len)--;
 	row = g_ms.terminfo.start.row;
 	tputs(tgoto(g_ms.terminfo.def.cm, 0, row), 1, ft_putchar);
 	tputs(g_ms.terminfo.def.cd, 1, ft_putchar);
 	ft_putstr_fd(PROMPT, STDERR_FILENO);
 	write(STDERR_FILENO, pre_line, *len);
+}
+
+int
+	ft_backspace(const char *pre_line, size_t *len)
+{
+	(*len)--;
+	put_line(pre_line, len);
+	if (g_ms.terminfo.current.col == 1)
+	{
+		tputs(tgoto(g_ms.terminfo.def.cm, 0, g_ms.terminfo.current.row),
+			1, ft_putchar);
+	}
 	return (GNL_SUCCESS);
 }
 

--- a/srcs/termcaps/get_line.c
+++ b/srcs/termcaps/get_line.c
@@ -3,56 +3,32 @@
 int
 	ft_get_line(char **line)
 {
-	ssize_t	rc;
 	ssize_t	ret;
 	size_t	len;
-	size_t	allocated;
-	char	buf[4];
 	char	*pre_line;
 
 	if (!line)
 		return (GNL_ERROR);
 	*line = NULL;
 	len = 0;
-	ft_bzero(buf, sizeof(buf));
 	pre_line = (char *)malloc(BUFFER_SIZE);
-	allocated = BUFFER_SIZE;
 	if (!pre_line)
 	{
 		ft_put_error(strerror(errno));
 		return (GNL_ERROR);
 	}
 	tcsetattr(STDIN_FILENO, TCSANOW, &g_ms.ms_term);
-	if (ft_get_cursor_position(
-		&(g_ms.terminfo.start.row), &(g_ms.terminfo.start.col))
-		== UTIL_ERROR)
+	if (ft_get_cursor_position(&(g_ms.terminfo.start.row),
+			&(g_ms.terminfo.start.col)) == UTIL_ERROR)
 		return (GNL_ERROR);
-	ft_putstr_fd(PROMPT, STDERR_FILENO);
-	rc = read(STDIN_FILENO, buf, sizeof(buf) / sizeof(buf[0]));
-	while (0 <= rc)
-	{
-		ft_update_current_position();
-		if (g_ms.interrupted == TRUE)
-		{
-			g_ms.interrupted = FALSE;
-			len = 0;
-		}
-		ret = ft_handle_keys(buf, pre_line, &len, &allocated);
-		if (ret < 0 || ret == GNL_EOF)
-		{
-			rc = ret;
-			break ;
-		}
-		ft_bzero(buf, sizeof(buf));
-		rc = read(STDIN_FILENO, buf, sizeof(buf) / sizeof(buf[0]));
-	}
+	ret = ft_handle_keys_loop(pre_line, &len);
 	tcsetattr(STDIN_FILENO, TCSANOW, &g_ms.origin_term);
-	if (0 <= rc)
+	if (0 <= ret)
 		*line = ft_substr(pre_line, 0, len);
 	ft_free(&pre_line);
-	if ((0 <= rc && !*line) || rc < 0)
+	if ((0 <= ret && !*line) || ret < 0)
 	{
-		if (rc != IS_OVERFLOW)
+		if (ret != IS_OVERFLOW)
 			ft_put_error(strerror(errno));
 		return (GNL_ERROR);
 	}

--- a/srcs/termcaps/handle_keys.c
+++ b/srcs/termcaps/handle_keys.c
@@ -1,9 +1,11 @@
 #include "minishell_tnishina.h"
 
-int
-	ft_handle_keys(const char *buf, char *pre_line,
+static int
+	handle_keys(const char *buf, char *pre_line,
 		size_t *len, size_t *allocated)
 {
+	ft_get_win_size();
+	ft_update_current_position();
 	if (*buf == '\n' || *buf == '\r')
 	{
 		write(STDERR_FILENO, "\n", 1);
@@ -21,4 +23,31 @@ int
 	else if (ft_isprint(*buf) && buf[1] == '\0')
 		return (ft_input_char(buf, pre_line, len, allocated));
 	return (GNL_SUCCESS);
+}
+
+int
+	ft_handle_keys_loop(char *pre_line, size_t *len)
+{
+	char	buf[4];
+	int		ret;
+	size_t	allocated;
+
+	ft_bzero(buf, sizeof(buf));
+	allocated = BUFFER_SIZE;
+	ft_putstr_fd(PROMPT, STDERR_FILENO);
+	ret = read(STDIN_FILENO, buf, sizeof(buf) / sizeof(buf[0]));
+	while (0 <= ret)
+	{
+		if (g_ms.interrupted == TRUE)
+		{
+			g_ms.interrupted = FALSE;
+			*len = 0;
+		}
+		ret = handle_keys(buf, pre_line, len, &allocated);
+		if (ret < 0 || ret == GNL_EOF)
+			break ;
+		ft_bzero(buf, sizeof(buf));
+		ret = read(STDIN_FILENO, buf, sizeof(buf) / sizeof(buf[0]));
+	}
+	return (ret);
 }


### PR DESCRIPTION
# 概要
isuue #145 端末入力バグ解消

# 受入条件
内容確認、動作確認

# コメント
- 「make termtest」の後、「./term.out」で起動できます。
- ２行目以降の先頭列でのバックスペースの処理を入れたので b06b96d で追加で頂いた内容も解消できているかと思います。
- minishell起動後にターミナルウインドウのサイズを変えると崩れるのは、ワカモレでも起きることなので、少しは良くなりましたが、あまり手を入れすぎずこの辺りで良いのではないかな、と思っています。。どうでしょうか？

before:
<img width="695" alt="スクリーンショット 2021-05-04 12 55 57" src="https://user-images.githubusercontent.com/13024418/116980496-4474a600-ad01-11eb-827c-873ead63d6e6.png">
after:
<img width="791" alt="スクリーンショット 2021-05-04 12 56 10" src="https://user-images.githubusercontent.com/13024418/116980527-4c344a80-ad01-11eb-831b-90d6cb9c2e12.png">

close #145