### PR TITLE
Feature/testscript

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ LFLAGS		:= -L${LIBDIR} -lft -lcurses
 
 CC			:= gcc
 CFLAGS		:= -Wall -Wextra -Werror
-# DEBUG		:= -g -fsanitize=address
-DEBUG		:=
+DEBUG		:= -g -fsanitize=address
+# DEBUG		:=
 
 RM			:= rm -f
 C_GREEN		:= "\x1b[32m"

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ LFLAGS		:= -L${LIBDIR} -lft -lcurses
 
 CC			:= gcc
 CFLAGS		:= -Wall -Wextra -Werror
-DEBUG		:= -g -fsanitize=address
-# DEBUG		:=
+# DEBUG		:= -g -fsanitize=address
+DEBUG		:=
 
 RM			:= rm -f
 C_GREEN		:= "\x1b[32m"

--- a/cdtest.sh
+++ b/cdtest.sh
@@ -13,13 +13,13 @@
 #
 ##########################
 
-if [ $1 = "leaks" ]; then
+if [ "$1" = "leaks" ]; then
     make cdltest # LEAK TEST
 else
     make cdtest
 fi
 
-if [ $1 = "make" ]; then
+if [ "$1" = "make" ]; then
     exit
 fi
 

--- a/echotest.sh
+++ b/echotest.sh
@@ -1,15 +1,27 @@
 #!/bin/bash
 
-cd libft
-make bonus
-cd ..
-gcc -g -Wall -Wextra -Werror -I./includes -I./libft -I./test \
-    test/test_builtin.c test/test_init.c test/test_exec.c test/test_launch.c \
-    srcs/echo.c srcs/cd.c srcs/pwd.c srcs/exit.c srcs/env.c srcs/unset.c \
-    srcs/export.c srcs/export_print.c srcs/export_setenv.c \
-    srcs/init_env.c srcs/env_utils.c srcs/env_utils2.c srcs/env_sort.c srcs/env_copy.c \
-    srcs/utils/utils.c srcs/utils/minishell_errors.c srcs/utils/command_utils.c srcs/utils/command_errors.c \
-    -Llibft -lft -D ECHOTEST -o builtin.out #-D LEAKS
+# USAGE ##################
+#
+# all test
+# ./echotest.sh
+#
+# all test with leaks
+# ./echotest.sh leaks
+#
+# make only
+# ./echotest.sh make
+#
+##########################
+
+if [ "$1" = "leaks" ]; then
+    make bltest # LEAK TEST
+else
+    make btest
+fi
+
+if [ "$1" = "make" ]; then
+    exit
+fi
 
 YELLOW=$(printf '\033[33m')
 CYAN=$(printf '\033[36m')

--- a/envtest.sh
+++ b/envtest.sh
@@ -1,15 +1,27 @@
 #!/bin/bash
 
-cd libft
-make bonus
-cd ..
-gcc -g -Wall -Wextra -Werror -I./includes -I./libft -I./test \
-    test/test_builtin.c test/test_init.c test/test_exec.c test/test_launch.c \
-    srcs/echo.c srcs/cd.c srcs/pwd.c srcs/exit.c srcs/env.c srcs/unset.c \
-    srcs/export.c srcs/export_print.c srcs/export_setenv.c \
-    srcs/init_env.c srcs/env_utils.c srcs/env_utils2.c srcs/env_sort.c srcs/env_copy.c \
-    srcs/utils/utils.c srcs/utils/minishell_errors.c srcs/utils/command_utils.c srcs/utils/command_errors.c \
-    -Llibft -lft -D ENVTEST -o builtin.out #-D LEAKS
+# USAGE ##################
+#
+# all test
+# ./envtest.sh
+#
+# all test with leaks
+# ./envtest.sh leaks
+#
+# make only
+# ./envtest.sh make
+#
+##########################
+
+if [ "$1" = "leaks" ]; then
+    make bltest # LEAK TEST
+else
+    make btest
+fi
+
+if [ "$1" = "make" ]; then
+    exit
+fi
 
 YELLOW=$(printf '\033[33m')
 CYAN=$(printf '\033[36m')

--- a/exittest.sh
+++ b/exittest.sh
@@ -1,15 +1,27 @@
 #!/bin/bash
 
-cd libft
-make bonus
-cd ..
-gcc -g -Wall -Wextra -Werror -I./includes -I./libft -I./test \
-    test/test_builtin.c test/test_init.c test/test_exec.c test/test_launch.c \
-    srcs/echo.c srcs/cd.c srcs/pwd.c srcs/exit.c srcs/env.c srcs/unset.c \
-    srcs/export.c srcs/export_print.c srcs/export_setenv.c \
-    srcs/init_env.c srcs/env_utils.c srcs/env_utils2.c srcs/env_sort.c srcs/env_copy.c \
-    srcs/utils/utils.c srcs/utils/minishell_errors.c srcs/utils/command_utils.c srcs/utils/command_errors.c \
-    -Llibft -lft -D EXITTEST -o builtin.out #-D LEAKS
+# USAGE ##################
+#
+# all test
+# ./exittest.sh
+#
+# all test with leaks
+# ./exittest.sh leaks
+#
+# make only
+# ./exittest.sh make
+#
+##########################
+
+if [ "$1" = "leaks" ]; then
+    make bltest # LEAK TEST
+else
+    make btest
+fi
+
+if [ "$1" = "make" ]; then
+    exit
+fi
 
 YELLOW=$(printf '\033[33m')
 RESET=$(printf '\033[0m')

--- a/exporttest.sh
+++ b/exporttest.sh
@@ -1,15 +1,27 @@
 #!/bin/bash
 
-cd libft
-make bonus
-cd ..
-gcc -g -Wall -Wextra -Werror -I./includes -I./libft -I./test \
-    test/test_builtin.c test/test_init.c test/test_exec.c test/test_launch.c \
-    srcs/echo.c srcs/cd.c srcs/pwd.c srcs/exit.c srcs/env.c srcs/unset.c \
-    srcs/export.c srcs/export_print.c srcs/export_setenv.c \
-    srcs/init_env.c srcs/env_utils.c srcs/env_utils2.c srcs/env_sort.c srcs/env_copy.c \
-    srcs/utils/utils.c srcs/utils/minishell_errors.c srcs/utils/command_utils.c srcs/utils/command_errors.c \
-    -Llibft -lft -D EXPORTTEST -o builtin.out #-D LEAKS
+# USAGE ##################
+#
+# all test
+# ./exporttest.sh
+#
+# all test with leaks
+# ./exporttest.sh leaks
+#
+# make only
+# ./exporttest.sh make
+#
+##########################
+
+if [ "$1" = "leaks" ]; then
+    make bltest # LEAK TEST
+else
+    make btest
+fi
+
+if [ "$1" = "make" ]; then
+    exit
+fi
 
 YELLOW=$(printf '\033[33m')
 CYAN=$(printf '\033[36m')
@@ -276,11 +288,6 @@ echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] export EXPORTTEST= 0123"
 echo "export EXPORTTEST= 0123" | bash
 echo $?
-echo "export EXPORTTEST= 0123 2> /dev/null ; export 1> bash_export" | bash
-echo "===diff check start==="
-diff mini_export bash_export
-echo "===diff check end==="
-rm mini_export bash_export
 echo
 
 # $mark
@@ -290,6 +297,7 @@ echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] export EXPORTTEST$=0123"
 echo "export EXPORTTEST$=0123" | bash
 echo $?
+rm mini_export bash_export
 echo
 
 # 先頭に数字
@@ -299,6 +307,7 @@ echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] export 0EXPORTTEST=0123"
 echo "export 0EXPORTTEST=0123" | bash
 echo $?
+rm mini_export bash_export
 echo
 
 # 途中に数字
@@ -376,11 +385,15 @@ echo
 
 # 既存の環境変数をnameのみで上書きしようとする -> 何もしない
 printf "${YELLOW}%s${RESET}\n" "[mini] export HOME"
-./builtin.out export HOME
+./builtin.out export HOME > mini_export
 echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] export HOME"
-echo "export HOME" | bash
+echo "export HOME ; export > bash_export" | bash
 echo $?
+echo "===diff check start==="
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
 echo
 
 # 既存の環境変数をnameのみで上書きしようとする -> 何もしない & 正常ケース
@@ -390,11 +403,7 @@ echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] export HOME EXPORTTEST=0123"
 echo "export HOME EXPORTTEST=0123" | bash
 echo $?
-echo "export HOME EXPORTTEST=0123 ; export > bash_export" | bash
-echo "===diff check start==="
-diff mini_export bash_export
-echo "===diff check end==="
-rm mini_export bash_export
+echo "export HOME EXPORTTEST=0123" | bash
 echo
 
 # 複数ダブルクォート
@@ -432,7 +441,7 @@ echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] export EXPORTTEST=012 EXPORTTEST+=34"
 echo "export EXPORTTEST=012 EXPORTTEST+=34" | bash
 echo $?
-echo "export EXPORTTEST=012 ; export > bash_export; EXPORTTEST+=34 ; export >> bash_export" | bash
+echo "export EXPORTTEST=012 ; EXPORTTEST+=34 ; export > bash_export" | bash
 echo "===diff check start==="
 diff mini_export bash_export
 echo "===diff check end==="
@@ -446,7 +455,7 @@ echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] export EXPORTTEST+=012 EXPORTTEST+=34 EXPORTTEST+=abc"
 echo "export EXPORTTEST+=012 EXPORTTEST+=34 EXPORTTEST+=abc" | bash
 echo $?
-echo "export EXPORTTEST+=012 ; export > bash_export; EXPORTTEST+=34 ; export >> bash_export ; EXPORTTEST+=abc ; export >> bash_export" | bash
+echo "export EXPORTTEST+=012 ; EXPORTTEST+=34 ; EXPORTTEST+=abc ; export > bash_export" | bash
 echo "===diff check start==="
 diff mini_export bash_export
 echo "===diff check end==="
@@ -494,6 +503,7 @@ echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] export"
 echo "export > bash_export" | bash
 echo $?
+rm mini_export bash_export
 export SHLVL=$MYSHLVL
 echo
 
@@ -507,6 +517,7 @@ echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] export"
 echo "export > bash_export" | bash
 echo $?
+rm mini_export bash_export
 export SHLVL=$MYSHLVL
 echo
 
@@ -520,6 +531,7 @@ echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] export"
 echo "export > bash_export" | bash
 echo $?
+rm mini_export bash_export
 export SHLVL=$MYSHLVL
 echo
 
@@ -533,6 +545,7 @@ echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] export"
 echo "export > bash_export" | bash
 echo $?
+rm mini_export bash_export
 export SHLVL=$MYSHLVL
 echo
 
@@ -546,6 +559,7 @@ echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] export"
 echo "export > bash_export" | bash
 echo $?
+rm mini_export bash_export
 export SHLVL=$MYSHLVL
 echo
 
@@ -559,5 +573,6 @@ echo $?
 printf "${YELLOW}%s${RESET}\n" "[bash] export"
 echo "export > bash_export" | bash
 echo $?
+rm mini_export bash_export
 export SHLVL=$MYSHLVL
 echo

--- a/pwdtest.sh
+++ b/pwdtest.sh
@@ -1,15 +1,27 @@
 #!/bin/bash
 
-cd libft
-make bonus
-cd ..
-gcc -g -Wall -Wextra -Werror -I./includes -I./libft -I./test \
-    test/test_builtin.c test/test_init.c test/test_exec.c test/test_launch.c \
-    srcs/echo.c srcs/cd.c srcs/pwd.c srcs/exit.c srcs/env.c srcs/unset.c \
-    srcs/export.c srcs/export_print.c srcs/export_setenv.c \
-    srcs/init_env.c srcs/env_utils.c srcs/env_utils2.c srcs/env_sort.c srcs/env_copy.c \
-    srcs/utils/utils.c srcs/utils/minishell_errors.c srcs/utils/command_utils.c srcs/utils/command_errors.c \
-    -Llibft -lft -D PWDTEST -o builtin.out #-D LEAKS
+# USAGE ##################
+#
+# all test
+# ./pwdtest.sh
+#
+# all test with leaks
+# ./pwdtest.sh leaks
+#
+# make only
+# ./pwdtest.sh make
+#
+##########################
+
+if [ "$1" = "leaks" ]; then
+    make bltest # LEAK TEST
+else
+    make btest
+fi
+
+if [ "$1" = "make" ]; then
+    exit
+fi
 
 YELLOW=$(printf '\033[33m')
 CYAN=$(printf '\033[36m')

--- a/test/test_exec.c
+++ b/test/test_exec.c
@@ -1,6 +1,22 @@
 #include "test_builtin.h"
 
 int
+	test_export(char **args)
+{
+	const char	*export_test[] = {"export", NULL};
+	int			ret;
+	t_bool		need_export;
+
+	need_export = FALSE;
+	if (args[1] && ft_strcmp(args[1], "--"))
+		need_export = TRUE;
+	ret = ft_export(args++);
+	if (g_status == EXIT_SUCCESS && need_export == TRUE)
+		ft_export((char **)export_test);
+	return (ret);
+}
+
+int
 	test_commands(char **args)
 {
 	int	ret;
@@ -21,7 +37,7 @@ int
 	else if (!ft_strcmp(args[1], "env"))
 		ret = ft_env(++args);
 	else if (!ft_strcmp(args[1], "export"))
-		ret = ft_export(++args);
+		ret = test_export(++args);
 	else if (!ft_strcmp(args[1], "unset"))
 		ret = ft_unset(++args);
 	else if (!ft_strcmp(args[1], "exit"))

--- a/unsettest.sh
+++ b/unsettest.sh
@@ -1,15 +1,27 @@
 #!/bin/bash
 
-cd libft
-make bonus
-cd ..
-gcc -g -Wall -Wextra -Werror -I./includes -I./libft -I./test \
-    test/test_builtin.c test/test_init.c test/test_exec.c test/test_launch.c \
-    srcs/echo.c srcs/cd.c srcs/pwd.c srcs/exit.c srcs/env.c srcs/unset.c \
-    srcs/export.c srcs/export_print.c srcs/export_setenv.c \
-    srcs/init_env.c srcs/env_utils.c srcs/env_utils2.c srcs/env_sort.c srcs/env_copy.c \
-    srcs/utils/utils.c srcs/utils/minishell_errors.c srcs/utils/command_utils.c srcs/utils/command_errors.c \
-    -Llibft -lft -D UNSETTEST -o builtin.out #-D LEAKS
+# USAGE ##################
+#
+# all test
+# ./unsettest.sh
+#
+# all test with leaks
+# ./unsettest.sh leaks
+#
+# make only
+# ./unsetest.sh make
+#
+##########################
+
+if [ "$1" = "leaks" ]; then
+    make bltest # LEAK TEST
+else
+    make btest
+fi
+
+if [ "$1" = "make" ]; then
+    exit
+fi
 
 YELLOW=$(printf '\033[33m')
 CYAN=$(printf '\033[36m')


### PR DESCRIPTION
# 概要
issue #156 ビルトイン関数のテストスクリプトが以前作ったままだったのでコンパイル等を更新しました

# 受入条件
動作確認

# コメント
- 各スクリプトを「./cdtest.sh」または「bash cdtest.sh」のようにして頂くとコンパイルしてテストケースの結果を出力します
- export.shは今のテスト用コードでは、以前のままのテストスクリプトの内容だとうまく動かない部分があったので、テスト用c言語コードとテストスクリプト双方を少し書き換えました

close #156 