### PR TITLE
Feature/cd_double_slash_path

### DIFF
--- a/cdtest.sh
+++ b/cdtest.sh
@@ -681,3 +681,59 @@ printf "PWD: ${PWD}\n"
 printf "OLDPWD: ${OLDPWD}\n"
 cd $WORKDIR
 echo
+
+printf "${CYAN}%s${RESET}\n" "pwd:
+${WORKDIR}"
+printf "${YELLOW}%s${RESET}\n" "[mini] cd //"
+./builtin.out cd //
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] cd //"
+cd //
+echo $?
+pwd
+printf "PWD: ${PWD}\n"
+printf "OLDPWD: ${OLDPWD}\n"
+cd $WORKDIR
+echo
+
+printf "${CYAN}%s${RESET}\n" "pwd:
+${WORKDIR}"
+printf "${YELLOW}%s${RESET}\n" "[mini] cd //Users//"
+./builtin.out cd //Users//
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] cd //Users//"
+cd //Users//
+echo $?
+pwd
+printf "PWD: ${PWD}\n"
+printf "OLDPWD: ${OLDPWD}\n"
+cd $WORKDIR
+echo
+
+printf "${CYAN}%s${RESET}\n" "pwd:
+${WORKDIR}"
+printf "${YELLOW}%s${RESET}\n" "[mini] cd //Users/../bin"
+./builtin.out cd //Users/../bin
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] cd //Users/../bin"
+cd //Users/../bin
+echo $?
+pwd
+printf "PWD: ${PWD}\n"
+printf "OLDPWD: ${OLDPWD}\n"
+cd $WORKDIR
+echo
+
+printf "${CYAN}%s${RESET}\n" "pwd:
+${WORKDIR}"
+printf "${YELLOW}%s${RESET}\n" "[mini] cd ///Users/../bin"
+./builtin.out cd ///Users/../bin
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] cd ///Users/../bin"
+cd ///Users/../bin
+echo $?
+pwd
+printf "PWD: ${PWD}\n"
+printf "OLDPWD: ${OLDPWD}\n"
+cd $WORKDIR
+echo

--- a/srcs/cd_fullpath.c
+++ b/srcs/cd_fullpath.c
@@ -76,6 +76,24 @@ static int
 	return (UTIL_SUCCESS);
 }
 
+static char
+	*add_slash_to_front(const char *input_path, char **full_path)
+{
+	char	*tmp;
+
+	if (2 <= ft_strlen(input_path)
+		&& !ft_strncmp(input_path, "//", 2)
+		&& input_path[2] != '/')
+	{
+		tmp = ft_join_path("", *full_path);
+		ft_free(full_path);
+		if (!tmp)
+			return (NULL);
+		*full_path = tmp;
+	}
+	return (*full_path);
+}
+
 char
 	*ft_make_full_path(const char *input_path)
 {
@@ -85,9 +103,8 @@ char
 	size_t	i;
 
 	input_split = ft_split(input_path, '/');
-	if (!input_split)
-		return (NULL);
-	if (make_path_list(&path_list, input_path, input_split, &i) == UTIL_ERROR)
+	if (!input_split || make_path_list(&path_list, input_path, input_split, &i)
+		== UTIL_ERROR)
 		return (NULL);
 	while (input_split[i])
 	{
@@ -103,5 +120,5 @@ char
 	ft_free_split(&input_split);
 	full_path = generate_path(path_list);
 	ft_lstclear(&path_list, free);
-	return (full_path);
+	return (add_slash_to_front(input_path, &full_path));
 }

--- a/srcs/utils/tlist_utils.c
+++ b/srcs/utils/tlist_utils.c
@@ -18,6 +18,8 @@ void
 	ft_lstdelone(current, del);
 	if (prev)
 		prev->next = NULL;
+	else
+		*lst = NULL;
 }
 
 int


### PR DESCRIPTION
# 概要
issue #150 cd関数を使って//で始まるパスへ移動したときの追加処理

# 受入条件
内容確認、動作確認（cdtest.sh）

# コメント
- 「./cdtest.sh」でbuiltin.outファイルをコンパイルしテストケースを実行します
- 「./builtin.out cd //」のようにしてもテストできます

close #150 