### PR TITLE
update to prefix path and to add help to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,38 @@
 NAME		:= minishell
 
-HISTDIR		:= ./srcs/history/
-UTILDIR		:= ./srcs/utils/
-TERMDIR		:= ./srcs/termcaps/
+SRCSDIR		:= ./srcs/
+HISTDIR		:= history/
+UTILDIR		:= utils/
+TERMDIR		:= termcaps/
 
-SRCS		:= srcs/init_minishell.c \
-				srcs/add_space.c \
-				srcs/cd.c srcs/cd_error.c srcs/cd_path_utils.c srcs/cd_fullpath.c \
-				srcs/echo.c srcs/pwd.c srcs/exit.c \
-				srcs/env.c srcs/unset.c \
-				srcs/extract_redirect.c \
-				srcs/export.c srcs/export_print.c srcs/export_setenv.c \
-				srcs/init_env.c srcs/env_utils.c srcs/env_utils2.c \
-				srcs/env_sort.c srcs/env_copy.c \
-				srcs/get_next_line.c srcs/make_token.c srcs/make_command.c srcs/expand_env.c \
-				srcs/handle_signal.c srcs/set_redirection.c \
+SRCS		:= init_minishell.c \
+				add_space.c \
+				cd.c cd_error.c cd_path_utils.c cd_fullpath.c \
+				echo.c pwd.c exit.c \
+				env.c unset.c \
+				extract_redirect.c \
+				export.c export_print.c export_setenv.c \
+				init_env.c env_utils.c env_utils2.c \
+				env_sort.c env_copy.c \
+				get_next_line.c make_token.c make_command.c expand_env.c \
+				handle_signal.c set_redirection.c \
 				$(HISTDIR)hlist_utils.c \
 				$(UTILDIR)command_utils.c $(UTILDIR)command_errors.c $(UTILDIR)minishell_errors.c \
 				$(UTILDIR)tlist_utils.c $(UTILDIR)split_utils.c $(UTILDIR)utils_tnishina.c $(UTILDIR)utils.c \
 				$(TERMDIR)edit_term_history.c $(TERMDIR)edit_term.c $(TERMDIR)get_line.c \
 				$(TERMDIR)handle_keys.c $(TERMDIR)init_term.c $(TERMDIR)term_utils.c
 SRCS_PRODUCTION	:= $(SRCS)
-SRCS_PRODUCTION	+= srcs/minishell.c
+SRCS_PRODUCTION	+= minishell.c
+SRCS_PRODUCTION	:= $(addprefix $(SRCSDIR), $(SRCS_PRODUCTION))
 OBJS_PRODUCTION	:= $(SRCS_PRODUCTION:.c=.o)
 
 SRCS_BUILTINTEST	:= $(SRCS)
+SRCS_BUILTINTEST	:= $(addprefix $(SRCSDIR), $(SRCS_BUILTINTEST))
 SRCS_BUILTINTEST	+= test/test_builtin.c test/test_init.c test/test_exec.c test/test_launch.c test/test_cd.c
 
 SRCS_TERMTEST	:= $(SRCS)
-SRCS_TERMTEST	+= srcs/minishell_term.c
+SRCS_TERMTEST	+= minishell_term.c
+SRCS_TERMTEST	:= $(addprefix $(SRCSDIR), $(SRCS_TERMTEST))
 
 INCLUDE		:= -I./includes/ -I./libft/ -I./test/
 
@@ -47,43 +51,46 @@ C_GREEN		:= "\x1b[32m"
 .c.o:
 			$(CC) $(CFLAGS) $(DEBUG) $(INCLUDE) -c $< -o $@
 
-all:		$(NAME)
+all:		$(NAME)	## `make' this program.
 
 $(NAME):	$(OBJS_PRODUCTION) $(LIBPATH)
 			$(CC) $(CFLAGS) $(OBJS_PRODUCTION) $(DEBUG) $(LFLAGS) -o $(NAME)
 			@echo $(C_GREEN)"=== Make Done ==="
 
-btest:		$(LIBPATH)
+btest:		$(LIBPATH)	## Compile for commands testing.
 			$(CC) $(CFLAGS) $(SRCS_BUILTINTEST) $(DEBUG) $(INCLUDE) $(LFLAGS) -D TEST -o builtin.out
 			@echo $(C_GREEN)"=== Make Done ==="
 
-bltest:		$(LIBPATH)
+bltest:		$(LIBPATH)	## Compile for commands testing with `leaks'.
 			$(CC) $(CFLAGS) $(SRCS_BUILTINTEST) $(DEBUG) $(INCLUDE) $(LFLAGS) -D CDTEST -D LEAKS -o builtin.out
 			@echo $(C_GREEN)"=== Make Done ==="
 
-cdtest:		$(LIBPATH)
+cdtest:		$(LIBPATH)	## Compile for cd command testing.
 			$(CC) $(CFLAGS) $(SRCS_BUILTINTEST) $(DEBUG) $(INCLUDE) $(LFLAGS) -D CDTEST -o builtin.out
 			@echo $(C_GREEN)"=== Make Done ==="
 
-cdltest:	$(LIBPATH)
+cdltest:	$(LIBPATH)	## Compile for cd command testing with `leaks'.
 			$(CC) $(CFLAGS) $(SRCS_BUILTINTEST) $(DEBUG) $(INCLUDE) $(LFLAGS) -D CDTEST -D LEAKS -o builtin.out
 			@echo $(C_GREEN)"=== Make Done ==="
 
-termtest:	$(LIBPATH)
+termtest:	$(LIBPATH)	## Compile for testing terminal operations.
 			$(CC) $(CFLAGS) $(SRCS_TERMTEST) $(DEBUG) $(INCLUDE) $(LFLAGS) -D TEST -o term.out
 			@echo $(C_GREEN)"=== Make Done ==="
 
 $(LIBPATH):
 			$(MAKE) -C $(LIBDIR)
 
-clean:
+clean:		## Remove all the temporary generated files.
 			$(RM) $(OBJS_PRODUCTION)
 			$(MAKE) clean -C $(LIBDIR)
 
-fclean:		clean
+fclean:		clean	## `make clean' plus all the binary made with `make all'.
 			$(RM) $(NAME)
 			$(MAKE) fclean -C $(LIBDIR)
 
-re:			fclean $(NAME)
+re:			fclean $(NAME)	## `make fclean' followed by `make all'.
+
+help:		## Display this help screen.
+			@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
 .PHONY:		all clean fclean re btest bltest cdtest cdltest termtest

--- a/Makefile
+++ b/Makefile
@@ -93,4 +93,4 @@ re:			fclean $(NAME)	## `make fclean' followed by `make all'.
 help:		## Display this help screen.
 			@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
-.PHONY:		all clean fclean re btest bltest cdtest cdltest termtest
+.PHONY:		all clean fclean re help btest bltest cdtest cdltest termtest


### PR DESCRIPTION
# 概要
Makefileで毎回srcsを付けるのが面倒＆長くなるのでaddprefixを使いました。
Makefileのルールが多いのでコメントを各ルールにつけ、「make help」でそのコメントが表示されるようにしました。

# 受入条件
内容確認、動作確認

# コメント
- 提案的な内容でもあるので有用そうであれば採用してください。
- srcsの指定の方は面倒なのでぜひ採用したいです。
- addprefixは[ノームの文書](https://elearning.intra.42.fr/notions/the-norm/subnotions/la-norme/pdfs/Norm)にも特に使ってはいけない等ありませんでした
- helpの方は以前Discordで紹介されていて気になっていたのでやってみました。[ここ](https://qiita.com/po3rin/items/7875ef9db5ca994ff762)を参考にしました。