### PR TITLE
fix #155 #159 to pass test case 5

### DIFF
--- a/includes/minishell_tnishina.h
+++ b/includes/minishell_tnishina.h
@@ -19,6 +19,7 @@
 
 # define PROMPT "minishell$ "
 # define EXIT_PROMPT "exit\n"
+# define STATUS_INVALID_COMMAND 2
 # define STATUS_CANNOT_EXECUTE 126
 # define STATUS_COMMAND_NOT_FOUND 127
 # define STATUS_SYNTAX_ERR 258
@@ -27,6 +28,10 @@
 # define APPEND_REDIRECT_OUT ">>"
 # define FD_MAX 255
 # define NEWLINE "newline"
+
+/* do_command parameters */
+
+# define NO_ERROR -1
 
 /* redirection parameters */
 
@@ -54,6 +59,7 @@
 # define FD_ERROR_MSG "Bad file descriptor"
 # define IS_DIR_ERROR_MSG "is a directory"
 # define COMMAND_NOT_FOUND_ERR_MSG "command not found"
+# define AMBIGUOUS_REDIRECT_ERR_MSG "ambiguous redirect"
 
 /*
 ** macro
@@ -66,6 +72,7 @@ typedef enum e_status
 	FAILED,
 	ENV_DELETED,
 	TOKEN_DELETED,
+	REDIRECT_DELETED,
 	COMPLETED
 }	t_status;
 

--- a/includes/minishell_tnishina.h
+++ b/includes/minishell_tnishina.h
@@ -19,7 +19,6 @@
 
 # define PROMPT "minishell$ "
 # define EXIT_PROMPT "exit\n"
-# define STATUS_INVALID_COMMAND 2
 # define STATUS_CANNOT_EXECUTE 126
 # define STATUS_COMMAND_NOT_FOUND 127
 # define STATUS_SYNTAX_ERR 258

--- a/srcs/exit.c
+++ b/srcs/exit.c
@@ -32,7 +32,6 @@ static int
 int
 	ft_exit(char **args)
 {
-	ft_putendl_fd("exit", STDERR_FILENO);
 	if (args[1])
 	{
 		if (!ft_strcmp(args[1], "--"))

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -151,19 +151,21 @@ void
 				if (buf.st_mode & S_IFDIR)
 				{
 					err_arg = ft_strdup(argv[0]);
-					err_msg = strdup(IS_DIR_ERROR_MSG);
+					err_msg = ft_strdup(IS_DIR_ERROR_MSG);
 					err_status = STATUS_COMMAND_NOT_FOUND;
 				}
 				if (execve(argv[0], argv, environ) < 0)
 				{
 					err_arg = ft_strdup(argv[0]);
-					err_msg = strdup(strerror(errno));
+					err_msg = ft_strdup(strerror(errno));
 					err_status = STATUS_CANNOT_EXECUTE;
 				}
 			}
 			paths++;
 		}
 		ft_do_command_err(command, err_arg, err_msg, err_status);
+		ft_free(&err_msg);
+		ft_free(&err_arg);
 		ft_free(&command);
 		ft_free(&path_env);
 		ft_free_split(&head);
@@ -453,7 +455,7 @@ int
 			}
 			if (res == EXIT)
 			{
-				ft_putendl_fd("exit", STDERR_FILENO);
+				ft_putstr_fd(EXIT_PROMPT, STDERR_FILENO);
 				break;
 			}
 		}

--- a/srcs/set_redirection.c
+++ b/srcs/set_redirection.c
@@ -143,7 +143,10 @@ t_bool
 	{
 		fd_from = get_fd((char *)(rd->content));
 		if (fd_from == OVER_INT_RANGE || FD_MAX < fd_from)
+		{
+			g_status = STATUS_GENERAL_ERR;
 			ft_put_fderror(fd_from);
+		}
 		redirect_op = get_op((char *)(rd->content));
 		path = ft_strdup((char *)(rd->next->content));
 		if (fd_from <= TOKEN_ERROR || FD_MAX < fd_from || !redirect_op || !path)


### PR DESCRIPTION
# 概要
以下の対応をしました。
- #155 #159 へ対応
- 子プロセスの終了ステータスをWIFEXITED, WEXITSTATUSを使って取得
- do_commandでパスを検索する際に、途中でエラーがあっても一旦最後まで検索しきるように修正
- リダイレクトの際に、ファイル名に無効な環境変数が入っていた場合のエラーメッセージを追加

# 受入条件
内容確認、動作確認

# コメント
- こちら、対応が時間かかってしまいすいません。。。 #155 でご指摘頂いた環境変数の展開の部分で結構手こずってしまいました
- 終了ステータスの部分はまだ対応しきれていない部分があるのでイシューとしては残してあります。nfukadaさんのテストケースをベースにいろいろ試しているところです
- 私のローカルではnfukadaさんのケースで273/344までいきました

close #155 
close #159 