### PR TITLE
update #165 _+ arg of export function

### DIFF
--- a/exporttest.sh
+++ b/exporttest.sh
@@ -34,6 +34,8 @@ printf "${YELLOW}%s${RESET}\n" "[bash] export"
 echo "export > bash_export" | bash
 echo $?
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
@@ -46,6 +48,8 @@ printf "${YELLOW}%s${RESET}\n" "[bash] export --"
 echo "export -- > bash_export" | bash
 echo $?
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
@@ -62,6 +66,8 @@ printf "${YELLOW}%s${RESET}\n" "[bash] export"
 echo "export > bash_export" | bash
 echo $?
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 printf "${CYAN}%s${RESET}\n" "unset EXPORTTEST"
@@ -81,6 +87,8 @@ printf "${YELLOW}%s${RESET}\n" "[bash] export"
 echo "export > bash_export" | bash
 echo $?
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
@@ -134,6 +142,8 @@ echo "export EXPORTTEST" | bash
 echo $?
 echo "export EXPORTTEST; export > bash_export" | bash
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
@@ -147,6 +157,8 @@ echo "export EXPORTTEST=" | bash
 echo $?
 echo "export EXPORTTEST= ; export > bash_export" | bash
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
@@ -160,6 +172,8 @@ echo "export EXPORTTEST=0123" | bash
 echo $?
 echo "export EXPORTTEST=0123 ; export > bash_export" | bash
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
@@ -186,6 +200,8 @@ echo "export \"EXPORTTEST=B\"=C" | bash
 echo $?
 echo "export \"EXPORTTEST=B\"=C ; export > bash_export" | bash
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
@@ -199,6 +215,8 @@ echo "export EXPORTTEST=\"aaa     b\"" | bash
 echo $?
 echo "export EXPORTTEST=\"aaa     b\" ; export > bash_export" | bash
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
@@ -212,6 +230,8 @@ echo "export EXPORTTEST===" | bash
 echo $?
 echo "export EXPORTTEST=== ; export > bash_export" | bash
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
@@ -225,6 +245,8 @@ echo "export EXPORTTEST=\\\"hello\\\"" | bash
 echo $?
 echo "export EXPORTTEST=\\\"hello\\\" ; export > bash_export" | bash
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
@@ -238,6 +260,8 @@ echo "export EXPORTTEST=\\\$hello" | bash
 echo $?
 echo "export EXPORTTEST=\\\$hello ; export > bash_export" | bash
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
@@ -251,6 +275,8 @@ echo "export EXPORTTEST=\\\\hello" | bash
 echo $?
 echo "export EXPORTTEST=\\\\hello ; export > bash_export" | bash
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
@@ -264,6 +290,8 @@ echo "export EXPORTTEST=\\\`hello" | bash
 echo $?
 echo "export EXPORTTEST=\\\`hello ; export > bash_export" | bash
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
@@ -277,6 +305,8 @@ echo "export EXPORTTEST=\" hello\"" | bash
 echo $?
 echo "export EXPORTTEST=\" hello\" ; export > bash_export" | bash
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
@@ -319,6 +349,8 @@ echo "export EXPORT0TEST=0123" | bash
 echo $?
 echo "export EXPORT0TEST=0123 ; export> bash_export" | bash
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
@@ -333,6 +365,8 @@ echo "export EXPORTTEST0=0123" | bash
 echo $?
 echo "export EXPORTTEST0=0123 ; export > bash_export" | bash
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
@@ -347,6 +381,8 @@ echo "export _A=0123" | bash
 echo $?
 echo "export _A=0123 ; export > bash_export" | bash
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
@@ -361,6 +397,8 @@ echo "export OLDPWD=override_oldpwd" | bash
 echo $?
 echo "export OLDPWD=override_oldpwd ; export > bash_export" | bash
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
@@ -378,6 +416,8 @@ printf "${YELLOW}%s${RESET}\n" "[bash] export"
 echo "export > bash_export" | bash
 echo $?
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
@@ -391,6 +431,8 @@ printf "${YELLOW}%s${RESET}\n" "[bash] export HOME"
 echo "export HOME ; export > bash_export" | bash
 echo $?
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
@@ -415,6 +457,8 @@ echo "export EXPORTTEST=\"echo \"\$USER\"\"" | bash
 echo $?
 echo "export EXPORTTEST=\"echo \"\$USER\"\" ; export > bash_export" | bash
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
@@ -429,6 +473,8 @@ echo "export EXPORTTEST+=012" | bash
 echo $?
 echo "export EXPORTTEST+=012 ; export > bash_export" | bash
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
@@ -443,6 +489,8 @@ echo "export EXPORTTEST=012 EXPORTTEST+=34" | bash
 echo $?
 echo "export EXPORTTEST=012 ; EXPORTTEST+=34 ; export > bash_export" | bash
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
@@ -457,6 +505,8 @@ echo "export EXPORTTEST+=012 EXPORTTEST+=34 EXPORTTEST+=abc" | bash
 echo $?
 echo "export EXPORTTEST+=012 ; EXPORTTEST+=34 ; EXPORTTEST+=abc ; export > bash_export" | bash
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
@@ -471,9 +521,61 @@ echo "export EXPORTTEST+=" | bash
 echo $?
 echo "export EXPORTTEST+= ; export > bash_export" | bash
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export
+echo
+
+# _+=
+printf "${YELLOW}%s${RESET}\n" "[mini] export _+="
+./builtin.out export _+= > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export _+="
+echo "export _+=" | bash
+echo $?
+echo "export _+= ; export > bash_export" | bash
+echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+
+# __+=
+printf "${YELLOW}%s${RESET}\n" "[mini] export __+="
+./builtin.out export __+= > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export __+="
+echo "export __+=" | bash
+echo $?
+echo "export __+= ; export > bash_export" | bash
+echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
+diff mini_export bash_export
+echo "===diff check end==="
+rm mini_export bash_export
+echo
+
+# _+
+printf "${YELLOW}%s${RESET}\n" "[mini] export _+"
+./builtin.out export _+ > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export _+"
+echo "export _+" | bash
+echo $?
+echo
+
+# __+
+printf "${YELLOW}%s${RESET}\n" "[mini] export __+"
+./builtin.out export __+ > mini_export
+echo $?
+printf "${YELLOW}%s${RESET}\n" "[bash] export __+"
+echo "export __+" | bash
+echo $?
 echo
 
 # unset SHLVL; export;
@@ -487,6 +589,8 @@ printf "${YELLOW}%s${RESET}\n" "[bash] export"
 echo "export > bash_export" | bash
 echo $?
 echo "===diff check start==="
+cat mini_export | grep -vE '^declare -x _=' > mini_export
+cat bash_export | grep -vE '^declare -x _=' > bash_export
 diff mini_export bash_export
 echo "===diff check end==="
 rm mini_export bash_export

--- a/srcs/export.c
+++ b/srcs/export.c
@@ -29,12 +29,12 @@ static t_bool
 }
 
 static t_bool
-	is_plus_mode(char *name)
+	is_plus_mode(const char *arg, char *name)
 {
 	size_t	len;
 
 	len = ft_strlen(name);
-	if (len && name[len - 1] == '+')
+	if (len && name[len - 1] == '+' && arg[len] == '=')
 	{
 		name[len - 1] = '\0';
 		if (ft_getenv(name))
@@ -54,7 +54,7 @@ static int
 		name = ft_extract_envname_from_str(args[1]);
 		if (!name)
 			return (stop_with_puterror(errno));
-		plus_mode = is_plus_mode(name);
+		plus_mode = is_plus_mode(args[1], name);
 		if (validate_name(name) == FALSE)
 		{
 			g_status = STATUS_GENERAL_ERR;


### PR DESCRIPTION
# 概要
issue #165 export関数_+、__+のような引数のときにエラーを出すように

# 受入条件
内容確認、動作確認（exporttest.sh）

# コメント
- 「./exporttest.sh」でコンパイルとテストケースの実行をします
- _+のような引数のときに、環境変数へのappendと判定されないようにしました

close #165 