### PR TITLE
Feature/redirect rev

### DIFF
--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -221,8 +221,8 @@ int
 		else if (!ft_strcmp(argv[0], "exit"))
 			res = ft_exit(argv);
 		ft_clear_argv(&argv);
-		ft_restore_fds(std_fds);
 	}
+	ft_restore_fds(std_fds);
 	return (res);
 }
 

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -99,6 +99,8 @@ void
 
 	if (!c || !environ)
 		exit(STATUS_GENERAL_ERR);
+	if (!c->args)
+		exit(g_status);
 	argv = ft_convert_list(c->args);
 	if (!argv)
 		exit(STATUS_GENERAL_ERR);
@@ -192,45 +194,49 @@ int
 	int		res;
 	int		std_fds[3];
 
-	res = STOP;
+	res = KEEP_RUNNING;
 	ft_save_fds(std_fds);
 	if (ft_set_redirection(c->redirects) == FALSE)
-		return (res);
-	argv = ft_convert_list(c->args);
-	if (!argv)
-	{
-		g_status = 1;
 		return (STOP);
+	if (c->args)
+	{
+		argv = ft_convert_list(c->args);
+		if (!argv)
+		{
+			g_status = 1;
+			return (STOP);
+		}
+		if (!ft_strcmp(argv[0], "echo"))
+			res = ft_echo(argv);
+		else if (!ft_strcmp(argv[0], "cd"))
+			res = ft_cd(argv);
+		else if (!ft_strcmp(argv[0], "pwd"))
+			res = ft_pwd(argv);
+		else if (!ft_strcmp(argv[0], "export"))
+			res = ft_export(argv);
+		else if (!ft_strcmp(argv[0], "unset"))
+			res = ft_unset(argv);
+		else if (!ft_strcmp(argv[0], "env"))
+			res = ft_env(argv);
+		else if (!ft_strcmp(argv[0], "exit"))
+			res = ft_exit(argv);
+		ft_clear_argv(&argv);
+		ft_restore_fds(std_fds);
 	}
-	if (!ft_strcmp(argv[0], "echo"))
-		res = ft_echo(argv);
-	else if (!ft_strcmp(argv[0], "cd"))
-		res = ft_cd(argv);
-	else if (!ft_strcmp(argv[0], "pwd"))
-		res = ft_pwd(argv);
-	else if (!ft_strcmp(argv[0], "export"))
-		res = ft_export(argv);
-	else if (!ft_strcmp(argv[0], "unset"))
-		res = ft_unset(argv);
-	else if (!ft_strcmp(argv[0], "env"))
-		res = ft_env(argv);
-	else if (!ft_strcmp(argv[0], "exit"))
-		res = ft_exit(argv);
-	ft_clear_argv(&argv);
-	ft_restore_fds(std_fds);
 	return (res);
 }
 
 static t_bool
 	is_builtin(t_command *c)
 {
-	if (!ft_strcmp((char* )(c->args->content), "echo")
+	if (c->args
+		&& (!ft_strcmp((char* )(c->args->content), "echo")
 		|| !ft_strcmp((char* )(c->args->content), "cd")
 		|| !ft_strcmp((char* )(c->args->content), "pwd")
 		|| !ft_strcmp((char* )(c->args->content), "export")
 		|| !ft_strcmp((char* )(c->args->content), "unset")
 		|| !ft_strcmp((char* )(c->args->content), "env")
-		|| !ft_strcmp((char* )(c->args->content), "exit"))
+		|| !ft_strcmp((char* )(c->args->content), "exit")))
 		return (TRUE);
 	else
 		return (FALSE);

--- a/srcs/set_redirection.c
+++ b/srcs/set_redirection.c
@@ -16,9 +16,12 @@ void
 	dup2(std_fds[0], STDIN_FILENO);
 	dup2(std_fds[1], STDOUT_FILENO);
 	dup2(std_fds[2], STDERR_FILENO);
-	close(std_fds[0]);
-	close(std_fds[1]);
-	close(std_fds[2]);
+	if (std_fds[0] != STDIN_FILENO)
+		close(std_fds[0]);
+	if (std_fds[1] != STDOUT_FILENO)
+		close(std_fds[1]);
+	if (std_fds[2] != STDERR_FILENO)
+		close(std_fds[2]);
 }
 
 static int
@@ -75,7 +78,8 @@ static t_bool
 	if (fd_from == NO_FD_SETTING)
 		fd_from = STDOUT_FILENO;
 	dup2(fd_to, fd_from);
-	close(fd_to);
+	if (fd_to != fd_from)
+		close(fd_to);
 	return (TRUE);
 }
 
@@ -94,7 +98,8 @@ static t_bool
 	if (fd_from == NO_FD_SETTING)
 		fd_from = STDOUT_FILENO;
 	dup2(fd_to, fd_from);
-	close(fd_to);
+	if (fd_to != fd_from)
+		close(fd_to);
 	return (TRUE);
 }
 
@@ -113,7 +118,8 @@ static t_bool
 	if (fd_from == NO_FD_SETTING)
 		fd_from = STDIN_FILENO;
 	dup2(fd_to, fd_from);
-	close(fd_to);
+	if (fd_to != fd_from)
+		close(fd_to);
 	return (TRUE);
 }
 


### PR DESCRIPTION
# 概要
#170 #171 の対応

# 受入条件
内容確認、動作確認

# コメント
- #170 の方は、c->redirectしかコマンドが持っていない場合に、c->argsの要素にアクセスしてしまっている部分があったため、その部分の実装を修正しています
- #171 については、fd_toで新たに開いたファイルディスクリプターとfd_fromが同じ値だった場合に、closeしてしまっていたのが原因でした。なので、closeの前に条件分岐を追加しています

close #170 
close #171 