### PR TITLE
Feature/test case6

### DIFF
--- a/includes/minishell_sikeda.h
+++ b/includes/minishell_sikeda.h
@@ -41,7 +41,8 @@ typedef enum e_cmd_signal
 {
 	KEEP_RUNNING,
 	STOP,
-	EXIT
+	EXIT,
+	EXIT_NON_NUMERIC
 }	t_cmd_signal;
 
 typedef struct s_history

--- a/includes/minishell_sikeda.h
+++ b/includes/minishell_sikeda.h
@@ -159,6 +159,7 @@ int		ft_pwd(char **args);
 
 /* export.c */
 int		ft_export(char **args);
+t_bool	ft_validate_name(const char *arg);
 
 /* export_print.c */
 int		ft_print_export(void);

--- a/ourtest.txt
+++ b/ourtest.txt
@@ -1,0 +1,26 @@
+echo "\\"
+echo '\'
+echo \
+echo \\
+echo \\\
+echo \\\\
+echo \\\\\
+echo \\\\\\
+env | grep "TERM"
+whoami | grep $USER
+cat Makefile | grep "FLAGS"
+/PWD
+.
+/
+exit "1"23
+exit 0 0 ; echo if you see this message then your minishell have some troubles
+echo '$USER'"123$USER123""text" > file ; cat file
+echo "-n -n -n"-n bonjour\
+cd / ; bin/no_commands
+nodir/no_command
+/nodir/no_command
+no_command
+export TEST="cho test"; e$TEST
+export TEST="cho test"; export TEST2=$TEST; echo $TEST2
+export TEST="cho test"; export 123=$TEST
+exprot TEST="cho test"; export TEST2=e$TEST $TEST

--- a/srcs/exit.c
+++ b/srcs/exit.c
@@ -1,4 +1,27 @@
 #include "minishell_sikeda.h"
+#include "minishell_tnishina.h"
+
+static int
+	exit_with_too_many_args(char **trimmed_arg)
+{
+	ft_putstr_fd(EXIT_PROMPT, STDERR_FILENO);
+	ft_put_cmderror("exit", "too many arguments");
+	g_status = STATUS_GENERAL_ERR;
+	if (*trimmed_arg)
+		ft_free(trimmed_arg);
+	return (STOP);
+}
+
+static int
+	exit_with_non_numeric(char *arg, char **trimmed_arg)
+{
+	ft_putstr_fd(EXIT_PROMPT, STDERR_FILENO);
+	ft_put_cmderror_with_arg("exit", "numeric argument required", arg);
+	g_status = STATUS_OUT_OF_RANGE_ERR;
+	if (*trimmed_arg)
+		ft_free(trimmed_arg);
+	return (EXIT_NON_NUMERIC);
+}
 
 static int
 	exit_with_args(char **args)
@@ -12,18 +35,10 @@ static int
 	{
 		g_status = (uint8_t)ft_atoi(trimmed_arg);
 		if (args[2])
-		{
-			ft_put_cmderror("exit", "too many arguments");
-			g_status = STATUS_GENERAL_ERR;
-			ft_free(&trimmed_arg);
-			return (STOP);
-		}
+			return (exit_with_too_many_args(&trimmed_arg));
 	}
 	else
-	{
-		ft_put_cmderror_with_arg("exit", "numeric argument required", args[1]);
-		g_status = STATUS_OUT_OF_RANGE_ERR;
-	}
+		return (exit_with_non_numeric(args[1], &trimmed_arg));
 	if (trimmed_arg)
 		ft_free(&trimmed_arg);
 	return (EXIT);

--- a/srcs/export.c
+++ b/srcs/export.c
@@ -8,8 +8,8 @@ static int
 	return (STOP);
 }
 
-static t_bool
-	validate_name(const char *arg)
+t_bool
+	ft_validate_name(const char *arg)
 {
 	t_bool	ret;
 
@@ -55,7 +55,7 @@ static int
 		if (!name)
 			return (stop_with_puterror(errno));
 		plus_mode = is_plus_mode(args[1], name);
-		if (validate_name(name) == FALSE)
+		if (ft_validate_name(name) == FALSE)
 		{
 			g_status = STATUS_GENERAL_ERR;
 			ft_put_cmderror_with_quoted_arg(

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -513,9 +513,10 @@ int
 				}
 				commands = commands->next;
 			}
-			if (res == EXIT)
+			if (res == EXIT || res == EXIT_NON_NUMERIC)
 			{
-				ft_putstr_fd(EXIT_PROMPT, STDERR_FILENO);
+				if (res == EXIT)
+					ft_putstr_fd(EXIT_PROMPT, STDERR_FILENO);
 				break;
 			}
 		}
@@ -525,7 +526,6 @@ int
 	}
 	ft_free(&line);
 	ft_free(&trimmed);
-	get_next_line(STDIN_FILENO, NULL);
 	ft_clear_commands(&head);
 	ft_exit_n_free_g_vars(g_status);
 }

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -125,11 +125,11 @@ void
 	err_arg = NULL;
 	err_status = NO_ERROR;
 	path_env = ft_getenv("PATH");
-	if (command[0] == '/' || command[0] == '.' || !path_env || !*path_env)
+	command_dir = get_command_dir(command);
+	if (!command_dir)
+		ft_exit_n_free_g_vars(STATUS_GENERAL_ERR);
+	if (command[0] == '/' || command[0] == '.' || !path_env || !*path_env || *command_dir)
 	{
-		command_dir = get_command_dir(command);
-		if (!command_dir)
-			ft_exit_n_free_g_vars(STATUS_GENERAL_ERR);
 		if (*command_dir)
 		{
 			if (stat(command_dir, &buf) != 0)
@@ -172,6 +172,7 @@ void
 	}
 	else
 	{
+		ft_free(&command_dir);
 		path_env = get_pathenv(path_env);
 		paths = ft_split(path_env, ':');
 		if (!path_env || !paths)
@@ -186,35 +187,20 @@ void
 			if (!tmp || !argv[0])
 				ft_exit_n_free_g_vars(STATUS_GENERAL_ERR);
 			ft_free(&tmp);
-			command_dir = get_command_dir(command);
-			if (!command_dir)
-				ft_exit_n_free_g_vars(STATUS_GENERAL_ERR);
-			if (*command_dir)
-			{
-				if (stat(command_dir, &buf) != 0)
-				{
-					err_arg = ft_strdup(argv[0]);
-					err_msg = ft_strdup(strerror(errno));
-					err_status = STATUS_COMMAND_NOT_FOUND;
-				}
-				else if (!(buf.st_mode & S_IFDIR))
-				{
-					err_arg = ft_strdup(argv[0]);
-					err_msg = ft_strdup(IS_NOT_DIR_ERR_MSG);
-					err_status = STATUS_CANNOT_EXECUTE;
-				}
-			}
-			ft_free(&command_dir);
 			if (stat(argv[0], &buf) == 0)
 			{
 				if (buf.st_mode & S_IFDIR)
 				{
+					ft_free(&err_arg);
+					ft_free(&err_msg);
 					err_arg = ft_strdup(argv[0]);
 					err_msg = ft_strdup(IS_DIR_ERROR_MSG);
 					err_status = STATUS_COMMAND_NOT_FOUND;
 				}
 				else if (!(buf.st_mode & S_IRUSR) || !(buf.st_mode & S_IXUSR))
 				{
+					ft_free(&err_arg);
+					ft_free(&err_msg);
 					err_arg = ft_strdup(argv[0]);
 					err_msg = ft_strdup(PERMISSION_ERR_MSG);
 					err_status = STATUS_CANNOT_EXECUTE;


### PR DESCRIPTION
# 概要
#177 に対応しました。

# 受入条件
動作確認、内容確認

# コメント
- exitのエラーの際にexitが表示されるイシューに関しては、nonnumerical valueが与えられたときもexitが最初に表示されたあとにエラーメッセージが表示されていたので、合わせて修正を加えています
- command not foundのエラーメッセージは、argv[0]に入力されたコマンドにスラッシュが含まれている場合には表示されていなかったので、そのように実装を修正しています
- 環境変数の展開部分については、[こちら](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameters.html)の記述に基づいて、name=valueの形でtokenが与えられて、かつnameがvalid nameの場合にはvalueの中に環境変数が含まれていた際に、環境変数は展開されるもののword splittingはされない、という実装に修正しています。その関係で、export関数の際に作成していただいた関数をいくつか借用させていただくために、staticの関数をglobalに変換しています
- デグレードを防ぐために、これまでイシューとしてご指摘頂いたものの一部と今回のtest case用に自分で追加したテストケースをourtest.txtにまとめました。こちらをnfukadaさんのテスターのcasesのディレクトリにコピーしていただくと、nfukadaさんのテスターを動かすと自動でチェックしてもらえます。一部nfukadaさんのオリジナルのテスターと重複しているものもあるかと思います。まだourtest.txtに含めきれていないものもあるので、今後こちらに追加していこうと思います

close #177 