### PR TITLE
Feature/test case7

### DIFF
--- a/includes/minishell_tnishina.h
+++ b/includes/minishell_tnishina.h
@@ -92,12 +92,6 @@ typedef struct			s_command
 	t_bool				expanded;
 }						t_command;
 
-/* global variables to store fds for STDIN, STDOUT, STDERR */
-
-int		g_stdin;
-int		g_stdout;
-int		g_stderr;
-
 int			get_next_line(int fd, char **line);
 void		ft_free_str(char **str);
 int			ft_make_token(t_list **tokens, char *line, t_bool(*f)(char*, int, int*));
@@ -121,9 +115,9 @@ void		ft_sig_prior(void);
 void		ft_sig_post(void);
 
 /* set_redirection.c */
-t_bool		ft_set_redirection(t_list *rd);
-void		ft_save_fds(void);
-void		ft_restore_fds(void);
+t_bool		ft_set_redirection(t_list *rd, int std_fds[3]);
+void		ft_save_fds(int std_fds[3]);
+void		ft_restore_fds(int std_fds[3]);
 
 /* add_space.c */
 int			ft_add_space(char **l);

--- a/includes/minishell_tnishina.h
+++ b/includes/minishell_tnishina.h
@@ -92,6 +92,12 @@ typedef struct			s_command
 	t_bool				expanded;
 }						t_command;
 
+/* global variables to store fds for STDIN, STDOUT, STDERR */
+
+int		g_stdin;
+int		g_stdout;
+int		g_stderr;
+
 int			get_next_line(int fd, char **line);
 void		ft_free_str(char **str);
 int			ft_make_token(t_list **tokens, char *line, t_bool(*f)(char*, int, int*));
@@ -116,8 +122,8 @@ void		ft_sig_post(void);
 
 /* set_redirection.c */
 t_bool		ft_set_redirection(t_list *rd);
-void		ft_save_fds(int std_fds[3]);
-void		ft_restore_fds(int std_fds[3]);
+void		ft_save_fds(void);
+void		ft_restore_fds(void);
 
 /* add_space.c */
 int			ft_add_space(char **l);

--- a/ourtest.txt
+++ b/ourtest.txt
@@ -1,0 +1,51 @@
+echo "\\"
+echo '\'
+echo \
+echo \\
+echo \\\
+echo \\\\
+echo \\\\\
+echo \\\\\\
+env | grep "TERM"
+whoami | grep $USER
+cat Makefile | grep "FLAGS"
+/PWD
+.
+/
+exit "1"23
+exit 0 0 ; echo if you see this message then your minishell have some troubles
+exit 0 0
+echo '$USER'"123$USER123""text" > file ; cat file
+echo "-n -n -n"-n bonjour
+cd //; pwd
+cd / ; bin/no_commands
+nodir/no_command
+/nodir/no_command
+no_command
+export TEST="cho test"; e$TEST
+export TEST="cho test"; export TEST2=$TEST; echo $TEST2
+export TEST="cho test"; export 123=$TEST
+exprot TEST="cho test"; export TEST2=e$TEST $TEST
+whereis ls | cat -e | cat -e > test
+touch ">"
+echo something > > file
+file cd wtf ; cat file
+cat < Makefile > file
+export TEST=hello; echo $TEST
+echo $
+echo "$"
+echo \$
+echo "\$"
+echo \"\"
+echo $?$?
+echo $USER$?
+echo ""$?""
+cd /bin; unset PATH ls; export PATH=/sbin; ls
+export TEST="echo test"; export TEST2=$TEST; echo $TEST2
+echo hello | exit 254 | echo world
+exit 3 | exit 100
+file ; > file
+> file ; > file
+> file | > file
+< file
+whereis ls | cat -e | cat -e > test

--- a/srcs/make_command.c
+++ b/srcs/make_command.c
@@ -41,6 +41,7 @@ void
 		current = current->next;
 		delone_command(&prev);
 	}
+	*c = NULL;
 }
 
 static int

--- a/srcs/make_command.c
+++ b/srcs/make_command.c
@@ -110,6 +110,7 @@ static t_command
 	op = !tokens ? NEWLINE : (char*)tokens->content;
 	if (!(command->op = ft_strdup(op)))
 		return (NULL);
+	ft_lstclear(&tokens, free);
 	return (command);
 }
 

--- a/srcs/make_command.c
+++ b/srcs/make_command.c
@@ -110,7 +110,6 @@ static t_command
 	op = !tokens ? NEWLINE : (char*)tokens->content;
 	if (!(command->op = ft_strdup(op)))
 		return (NULL);
-	ft_lstclear(&tokens, free);
 	return (command);
 }
 
@@ -142,7 +141,7 @@ t_bool
 static t_bool
 	is_valid_command(t_command *c)
 {
-	t_list	*head;
+	t_list	*current;
 
 	if ((!(ft_strcmp(c->op, "|")) && !(c->args)) ||
 		(!(ft_strcmp(c->op, ";")) && !(c->args)))
@@ -150,25 +149,24 @@ static t_bool
 		ft_put_syntaxerror_with_token(c->op);
 		return (FALSE);
 	}
-	head = c->args;
-	while (c->args)
+	current = c->args;
+	while (current)
 	{
-		if (ft_is_redirect((char *)(c->args->content)))
+		if (ft_is_redirect((char *)(current->content)))
 		{
-			if (!(c->args->next))
+			if (!(current->next))
 			{
 				ft_put_syntaxerror_with_token(c->op);
 				return (FALSE);
 			}
-			else if (ft_is_redirect((char *)(c->args->next->content)))
+			else if (ft_is_redirect((char *)(current->next->content)))
 			{
-				ft_put_syntaxerror_with_token((char *)(c->args->next->content));
+				ft_put_syntaxerror_with_token((char *)(current->next->content));
 				return (FALSE);
 			}
 		}
-		c->args = c->args->next;
+		current = current->next;
 	}
-	c->args = head;
 	return (TRUE);
 }
 

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -241,10 +241,11 @@ int
 {
 	char	**argv;
 	int		res;
+	int		std_fds[3];
 
 	res = KEEP_RUNNING;
-	ft_save_fds();
-	if (ft_set_redirection(c->redirects) == FALSE)
+	ft_save_fds(std_fds);
+	if (ft_set_redirection(c->redirects, std_fds) == FALSE)
 		return (STOP);
 	if (c->args)
 	{
@@ -270,7 +271,7 @@ int
 			res = ft_exit(argv);
 		ft_clear_argv(&argv);
 	}
-	ft_restore_fds();
+	ft_restore_fds(std_fds);
 	return (res);
 }
 
@@ -295,6 +296,7 @@ static pid_t
 {
 	pid_t	pid;
 	int		newpipe[2];
+	int		std_fds[3];
 
 	if (ispipe)
 		pipe(newpipe);
@@ -318,8 +320,14 @@ static pid_t
 			ft_execute_builtin(c);
 			ft_exit_n_free_g_vars(g_status);
 		}
-		else if (ft_set_redirection(c->redirects))
-			do_command(c, environ);
+		else
+		{
+			ft_save_fds(std_fds);
+			if (ft_set_redirection(c->redirects, std_fds))
+				do_command(c, environ);
+			else
+				ft_exit_n_free_g_vars(g_status);
+		}
 	}
 	if (haspipe)
 	{

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -349,19 +349,12 @@ t_command
 		if (res == COMPLETED)
 		{
 			if (c->args || c->redirects)
-			{
 				c->pid = start_command(c, is_pipe(c), haspipe, lastpipe, environ);
-				haspipe = is_pipe(c);
-				if (haspipe)
-					c = c->next;
-				else
-					break ;
-			}
-			else
-			{
+			haspipe = is_pipe(c);
+			if (haspipe)
 				c = c->next;
-				break;
-			}
+			else
+				break ;
 		}
 		else if (res == REDIRECT_DELETED)
 		{

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -241,10 +241,9 @@ int
 {
 	char	**argv;
 	int		res;
-	int		std_fds[3];
 
 	res = KEEP_RUNNING;
-	ft_save_fds(std_fds);
+	ft_save_fds();
 	if (ft_set_redirection(c->redirects) == FALSE)
 		return (STOP);
 	if (c->args)
@@ -271,7 +270,7 @@ int
 			res = ft_exit(argv);
 		ft_clear_argv(&argv);
 	}
-	ft_restore_fds(std_fds);
+	ft_restore_fds();
 	return (res);
 }
 

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -306,13 +306,15 @@ static pid_t
 		if (haspipe)
 		{
 			close(lastpipe[1]);
-			dup2(lastpipe[0], STDIN_FILENO);
+			if (dup2(lastpipe[0], STDIN_FILENO) < 0)
+				ft_exit_n_free_g_vars(STATUS_GENERAL_ERR);
 			close(lastpipe[0]);
 		}
 		if (ispipe)
 		{
 			close(newpipe[0]);
-			dup2(newpipe[1], STDOUT_FILENO);
+			if (dup2(newpipe[1], STDOUT_FILENO) < 0)
+				ft_exit_n_free_g_vars(STATUS_GENERAL_ERR);
 			close(newpipe[1]);
 		}
 		if (is_builtin(c))

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -2,13 +2,6 @@
 #include "minishell_sikeda.h"
 #include "libft.h"
 
-void
-	exit_with_error(void)
-{
-	ft_put_error(strerror(errno));
-	ft_exit_n_free_g_vars(g_status);
-}
-
 static char
 	*get_pathenv(char *s)
 {
@@ -167,10 +160,7 @@ void
 			ft_exit_n_free_g_vars(g_status);
 		}
 		else
-		{
 			execve(argv[0], argv, environ);
-			ft_exit_n_free_g_vars(g_status);
-		}
 	}
 	else
 	{
@@ -510,7 +500,7 @@ int
 						}
 						commands = ft_execute_pipeline(commands, environ);
 						if (!commands || waitpid(commands->pid, &term_status, 0) < 0)
-							exit_with_error();
+							ft_exit_n_free_g_vars(STATUS_GENERAL_ERR);
 						if (WIFEXITED(term_status))
 							g_status = WEXITSTATUS(term_status);
 						else if (!commands)

--- a/srcs/set_redirection.c
+++ b/srcs/set_redirection.c
@@ -172,5 +172,7 @@ t_bool
 		ft_free(&path);
 		rd = rd->next->next;
 	}
+	if (res)
+		g_status = STATUS_SUCCESS;
 	return (res);
 }

--- a/srcs/set_redirection.c
+++ b/srcs/set_redirection.c
@@ -3,25 +3,25 @@
 #include "libft.h"
 
 void
-	ft_save_fds(int std_fds[3])
+	ft_save_fds(void)
 {
-	std_fds[0] = dup(STDIN_FILENO);
-	std_fds[1] = dup(STDOUT_FILENO);
-	std_fds[2] = dup(STDERR_FILENO);
+	g_stdin = dup(STDIN_FILENO);
+	g_stdout = dup(STDOUT_FILENO);
+	g_stderr = dup(STDERR_FILENO);
 }
 
 void
-	ft_restore_fds(int std_fds[3])
+	ft_restore_fds(void)
 {
-	dup2(std_fds[0], STDIN_FILENO);
-	dup2(std_fds[1], STDOUT_FILENO);
-	dup2(std_fds[2], STDERR_FILENO);
-	if (std_fds[0] != STDIN_FILENO)
-		close(std_fds[0]);
-	if (std_fds[1] != STDOUT_FILENO)
-		close(std_fds[1]);
-	if (std_fds[2] != STDERR_FILENO)
-		close(std_fds[2]);
+	dup2(g_stdin, STDIN_FILENO);
+	dup2(g_stdout, STDOUT_FILENO);
+	dup2(g_stderr, STDERR_FILENO);
+	if (g_stdin != STDIN_FILENO)
+		close(g_stdin);
+	if (g_stdout != STDOUT_FILENO)
+		close(g_stdout);
+	if (g_stderr != STDERR_FILENO)
+		close(g_stderr);
 }
 
 static int
@@ -97,6 +97,12 @@ static t_bool
 	}
 	if (fd_from == NO_FD_SETTING)
 		fd_from = STDOUT_FILENO;
+	else if (fd_from == g_stdin)
+		g_stdin = dup(fd_from);
+	else if (fd_from == g_stdout)
+		g_stdout = dup(fd_from);
+	else if (fd_from == g_stderr)
+		g_stderr = dup(fd_from);
 	dup2(fd_to, fd_from);
 	if (fd_to != fd_from)
 		close(fd_to);

--- a/srcs/set_redirection.c
+++ b/srcs/set_redirection.c
@@ -8,14 +8,20 @@ void
 	std_fds[0] = dup(STDIN_FILENO);
 	std_fds[1] = dup(STDOUT_FILENO);
 	std_fds[2] = dup(STDERR_FILENO);
+	if (std_fds[0] < 0 || std_fds[1] < 0 || std_fds[2] < 0)
+		ft_exit_n_free_g_vars(STATUS_GENERAL_ERR);
 }
 
 void
 	ft_restore_fds(int std_fds[3])
 {
-	dup2(std_fds[0], STDIN_FILENO);
-	dup2(std_fds[1], STDOUT_FILENO);
-	dup2(std_fds[2], STDERR_FILENO);
+	int	res[3];
+
+	res[0] = dup2(std_fds[0], STDIN_FILENO);
+	res[1] = dup2(std_fds[1], STDOUT_FILENO);
+	res[2] = dup2(std_fds[2], STDERR_FILENO);
+	if (res[0] < 0 || res[1] < 0 || res[1] < 0)
+		ft_exit_n_free_g_vars(STATUS_GENERAL_ERR);
 	if (std_fds[0] != STDIN_FILENO)
 		close(std_fds[0]);
 	if (std_fds[1] != STDOUT_FILENO)
@@ -83,7 +89,10 @@ static t_bool
 		std_fds[1] = dup(fd_from);
 	else if (fd_from == std_fds[2])
 		std_fds[2] = dup(fd_from);
-	dup2(fd_to, fd_from);
+	if (std_fds[0] < 0 || std_fds[1] < 0 || std_fds[2] < 0)
+		ft_exit_n_free_g_vars(STATUS_GENERAL_ERR);
+	if (dup2(fd_to, fd_from) < 0)
+		ft_exit_n_free_g_vars(STATUS_GENERAL_ERR);
 	if (fd_to != fd_from)
 		close(fd_to);
 	return (TRUE);
@@ -109,7 +118,10 @@ static t_bool
 		std_fds[1] = dup(fd_from);
 	else if (fd_from == std_fds[2])
 		std_fds[2] = dup(fd_from);
-	dup2(fd_to, fd_from);
+	if (std_fds[0] < 0 || std_fds[1] < 0 || std_fds[2] < 0)
+		ft_exit_n_free_g_vars(STATUS_GENERAL_ERR);
+	if (dup2(fd_to, fd_from) < 0)
+		ft_exit_n_free_g_vars(STATUS_GENERAL_ERR);
 	if (fd_to != fd_from)
 		close(fd_to);
 	return (TRUE);
@@ -135,7 +147,10 @@ static t_bool
 		std_fds[1] = dup(fd_from);
 	else if (fd_from == std_fds[2])
 		std_fds[2] = dup(fd_from);
-	dup2(fd_to, fd_from);
+	if (std_fds[0] < 0 || std_fds[1] < 0 || std_fds[2] < 0)
+		ft_exit_n_free_g_vars(STATUS_GENERAL_ERR);
+	if (dup2(fd_to, fd_from) < 0)
+		ft_exit_n_free_g_vars(STATUS_GENERAL_ERR);
 	if (fd_to != fd_from)
 		close(fd_to);
 	return (TRUE);

--- a/srcs/set_redirection.c
+++ b/srcs/set_redirection.c
@@ -3,25 +3,25 @@
 #include "libft.h"
 
 void
-	ft_save_fds(void)
+	ft_save_fds(int std_fds[3])
 {
-	g_stdin = dup(STDIN_FILENO);
-	g_stdout = dup(STDOUT_FILENO);
-	g_stderr = dup(STDERR_FILENO);
+	std_fds[0] = dup(STDIN_FILENO);
+	std_fds[1] = dup(STDOUT_FILENO);
+	std_fds[2] = dup(STDERR_FILENO);
 }
 
 void
-	ft_restore_fds(void)
+	ft_restore_fds(int std_fds[3])
 {
-	dup2(g_stdin, STDIN_FILENO);
-	dup2(g_stdout, STDOUT_FILENO);
-	dup2(g_stderr, STDERR_FILENO);
-	if (g_stdin != STDIN_FILENO)
-		close(g_stdin);
-	if (g_stdout != STDOUT_FILENO)
-		close(g_stdout);
-	if (g_stderr != STDERR_FILENO)
-		close(g_stderr);
+	dup2(std_fds[0], STDIN_FILENO);
+	dup2(std_fds[1], STDOUT_FILENO);
+	dup2(std_fds[2], STDERR_FILENO);
+	if (std_fds[0] != STDIN_FILENO)
+		close(std_fds[0]);
+	if (std_fds[1] != STDOUT_FILENO)
+		close(std_fds[1]);
+	if (std_fds[2] != STDERR_FILENO)
+		close(std_fds[2]);
 }
 
 static int
@@ -64,7 +64,7 @@ static char
 }
 
 static t_bool
-	append_redirect_out(int fd_from, char *path)
+	append_redirect_out(int fd_from, char *path, int std_fds[3])
 {
 	int	fd_to;
 
@@ -77,12 +77,12 @@ static t_bool
 	}
 	if (fd_from == NO_FD_SETTING)
 		fd_from = STDOUT_FILENO;
-	else if (fd_from == g_stdin)
-		g_stdin = dup(fd_from);
-	else if (fd_from == g_stdout)
-		g_stdout = dup(fd_from);
-	else if (fd_from == g_stderr)
-		g_stderr = dup(fd_from);
+	else if (fd_from == std_fds[0])
+		std_fds[0] = dup(fd_from);
+	else if (fd_from == std_fds[1])
+		std_fds[1] = dup(fd_from);
+	else if (fd_from == std_fds[2])
+		std_fds[2] = dup(fd_from);
 	dup2(fd_to, fd_from);
 	if (fd_to != fd_from)
 		close(fd_to);
@@ -90,7 +90,7 @@ static t_bool
 }
 
 static t_bool
-	redirect_out(int fd_from, char *path)
+	redirect_out(int fd_from, char *path, int std_fds[3])
 {
 	int	fd_to;
 
@@ -103,12 +103,12 @@ static t_bool
 	}
 	if (fd_from == NO_FD_SETTING)
 		fd_from = STDOUT_FILENO;
-	else if (fd_from == g_stdin)
-		g_stdin = dup(fd_from);
-	else if (fd_from == g_stdout)
-		g_stdout = dup(fd_from);
-	else if (fd_from == g_stderr)
-		g_stderr = dup(fd_from);
+	else if (fd_from == std_fds[0])
+		std_fds[0] = dup(fd_from);
+	else if (fd_from == std_fds[1])
+		std_fds[1] = dup(fd_from);
+	else if (fd_from == std_fds[2])
+		std_fds[2] = dup(fd_from);
 	dup2(fd_to, fd_from);
 	if (fd_to != fd_from)
 		close(fd_to);
@@ -116,7 +116,7 @@ static t_bool
 }
 
 static t_bool
-	redirect_in(int fd_from, char *path)
+	redirect_in(int fd_from, char *path, int std_fds[3])
 {
 	int	fd_to;
 
@@ -129,12 +129,12 @@ static t_bool
 	}
 	if (fd_from == NO_FD_SETTING)
 		fd_from = STDIN_FILENO;
-	else if (fd_from == g_stdin)
-		g_stdin = dup(fd_from);
-	else if (fd_from == g_stdout)
-		g_stdout = dup(fd_from);
-	else if (fd_from == g_stderr)
-		g_stderr = dup(fd_from);
+	else if (fd_from == std_fds[0])
+		std_fds[0] = dup(fd_from);
+	else if (fd_from == std_fds[1])
+		std_fds[1] = dup(fd_from);
+	else if (fd_from == std_fds[2])
+		std_fds[2] = dup(fd_from);
 	dup2(fd_to, fd_from);
 	if (fd_to != fd_from)
 		close(fd_to);
@@ -142,20 +142,20 @@ static t_bool
 }
 
 static t_bool
-	execute_redirection(int fd_from, char *redirect_op, char *path)
+	execute_redirection(int fd_from, char *redirect_op, char *path, int std_fds[3])
 {
 	if (!(ft_strcmp(redirect_op, APPEND_REDIRECT_OUT)))
-		return (append_redirect_out(fd_from, path));
+		return (append_redirect_out(fd_from, path, std_fds));
 	else if (!(ft_strcmp(redirect_op, REDIRECT_OUT)))
-		return (redirect_out(fd_from, path));
+		return (redirect_out(fd_from, path, std_fds));
 	else if (!(ft_strcmp(redirect_op, REDIRECT_IN)))
-		return (redirect_in(fd_from, path));
+		return (redirect_in(fd_from, path, std_fds));
 	else
 		return (FALSE);
 }
 
 t_bool
-	ft_set_redirection(t_list *rd)
+	ft_set_redirection(t_list *rd, int std_fds[3])
 {
 	int		fd_from;
 	char	*path;
@@ -178,7 +178,7 @@ t_bool
 			g_status = STATUS_GENERAL_ERR;
 			return (FALSE);
 		}
-		if (!execute_redirection(fd_from, redirect_op, path))
+		if (!execute_redirection(fd_from, redirect_op, path, std_fds))
 			res = FALSE;
 		ft_free(&redirect_op);
 		ft_free(&path);

--- a/srcs/set_redirection.c
+++ b/srcs/set_redirection.c
@@ -77,6 +77,12 @@ static t_bool
 	}
 	if (fd_from == NO_FD_SETTING)
 		fd_from = STDOUT_FILENO;
+	else if (fd_from == g_stdin)
+		g_stdin = dup(fd_from);
+	else if (fd_from == g_stdout)
+		g_stdout = dup(fd_from);
+	else if (fd_from == g_stderr)
+		g_stderr = dup(fd_from);
 	dup2(fd_to, fd_from);
 	if (fd_to != fd_from)
 		close(fd_to);
@@ -123,6 +129,12 @@ static t_bool
 	}
 	if (fd_from == NO_FD_SETTING)
 		fd_from = STDIN_FILENO;
+	else if (fd_from == g_stdin)
+		g_stdin = dup(fd_from);
+	else if (fd_from == g_stdout)
+		g_stdout = dup(fd_from);
+	else if (fd_from == g_stderr)
+		g_stderr = dup(fd_from);
 	dup2(fd_to, fd_from);
 	if (fd_to != fd_from)
 		close(fd_to);

--- a/srcs/set_redirection.c
+++ b/srcs/set_redirection.c
@@ -15,12 +15,9 @@ void
 void
 	ft_restore_fds(int std_fds[3])
 {
-	int	res[3];
-
-	res[0] = dup2(std_fds[0], STDIN_FILENO);
-	res[1] = dup2(std_fds[1], STDOUT_FILENO);
-	res[2] = dup2(std_fds[2], STDERR_FILENO);
-	if (res[0] < 0 || res[1] < 0 || res[1] < 0)
+	if (dup2(std_fds[0], STDIN_FILENO) < 0
+		|| dup2(std_fds[1], STDOUT_FILENO) < 0
+		|| dup2(std_fds[2], STDERR_FILENO) < 0)
 		ft_exit_n_free_g_vars(STATUS_GENERAL_ERR);
 	if (std_fds[0] != STDIN_FILENO)
 		close(std_fds[0]);

--- a/srcs/utils/utils_tnishina.c
+++ b/srcs/utils/utils_tnishina.c
@@ -52,6 +52,8 @@ int
 {
 	uint64_t	num;
 	int			is_minus;
+
+	is_minus = 0;
 	while (ft_isspace(*s))
 		s++;
 	if (*s == '-')


### PR DESCRIPTION
# 概要
#115 #138 #166 #178 #181 の対応をしました

# 受入条件
内容確認、動作確認

# コメント
- ourtest.txtに今回の修正分も含めて、これまでご指摘いただいたテストケースを含めてあります。こちらをnfukadaさんのテストケースのcasesのディレクトリに入れていただくと、一気にチェックできます
- リダイレクトの部分でセグフォが起きていたところに関しては、標準入力、標準出力、標準エラー出力を示すファイルディスクリプターをグローバル変数で管理する形に変更して対応しました→その後、改めて考え直して、そこまでグローバル変数を使う必要もないかと思い直し、グローバル変数を使わない方法に実装を修正しました。グローバル変数を使った実装の方がいいかどうか、ご意見があればいただけると幸いです
- #115 についても一旦still reachable以外のメモリリークはなくせたかと思うので、まとめてプルリクさせて頂きます

close #115 
close #138 
close #166
close #178  
close #181 