### PR TITLE
fix #187 exit status when cpiped commands are stopped with signals

### DIFF
--- a/srcs/handle_signal.c
+++ b/srcs/handle_signal.c
@@ -15,15 +15,18 @@ void
 	sig_int_post()
 {
 	ft_putstr_fd("\n", STDERR_FILENO);
-	g_status = 130;
+	if (kill(g_latest_pid, 0) == 0)
+		g_status = 130;
 }
 
 void
 	sig_quit_post()
 {
 	if (kill(g_latest_pid, 0) == 0)
+	{
 		ft_putstr_fd("Quit: 3\n", STDERR_FILENO);
-	g_status = 131;
+		g_status = 131;
+	}
 }
 
 void

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -444,23 +444,19 @@ int
 	int			res;
 	int			expand_res;
 
-	if (ft_init_env() == STOP)
+	if (init_minishell() == UTIL_ERROR)
 		return (EXIT_FAILURE);
-	if (ft_init_pwd() == STOP)
-	{
-		ft_lstclear(&g_env, free);
-		return (EXIT_FAILURE);
-	}
+	line = NULL;
+	trimmed = NULL;
+	head = NULL;
 	while (1)
 	{
-		ft_putstr_fd(PROMPT, STDERR_FILENO);
 		ft_sig_prior();
-		res = get_next_line(STDIN_FILENO, &line);
-		get_next_line(STDIN_FILENO, NULL);
-		if (res == 0 && ft_strlen(line) == 0)
+		res = ft_get_line(&line);
+		if (res == GNL_ERROR)
 		{
-			ft_putstr_fd(EXIT_PROMPT, STDERR_FILENO);
-			ft_exit_n_free_g_vars(0);
+			g_status = STATUS_GENERAL_ERR;
+			break ;
 		}
 		ft_sig_post();
 		if (is_end_with_escape(line))

--- a/srcs/utils/utils_tnishina.c
+++ b/srcs/utils/utils_tnishina.c
@@ -78,5 +78,6 @@ void
 {
 	ft_free(&g_pwd);
 	ft_lstclear(&g_env, free);
+	ft_clear_history(&g_ms.hist.last);
 	exit(exit_status);
 }


### PR DESCRIPTION
# 概要
#187 に対応しました

# 受入条件
動作確認、動作確認

# コメント
- シグナルで終了させられたコマンドが一番最後のコマンドかどうかに応じて、g_statusを更新するように修正しました
- もともと別のプルリクで出していたGNLのft_get_lineでの置き換え部分を統合しました

close #187 