### PR TITLE
update #190 to make testing easier

### DIFF
--- a/srcs/init_minishell.c
+++ b/srcs/init_minishell.c
@@ -10,13 +10,6 @@ int
 		ft_lstclear(&g_env, free);
 		return (UTIL_ERROR);
 	}
-	if (ft_init_term() == UTIL_ERROR)
-	{
-		printf("error\n");
-		ft_lstclear(&g_env, free);
-		ft_free(&g_pwd);
-		return (UTIL_ERROR);
-	}
 	g_ms.interrupted = FALSE;
 	return (UTIL_SUCCESS);
 }

--- a/srcs/termcaps/init_term.c
+++ b/srcs/termcaps/init_term.c
@@ -38,7 +38,10 @@ int
 	}
 	ft_get_win_size();
 	if (get_definition_from_termcap() == UTIL_ERROR)
+	{
+		ft_put_error("Cannot find termcaps.");
 		return (UTIL_ERROR);
+	}
 	if (tcgetattr(STDIN_FILENO, &g_ms.ms_term) != 0)
 	{
 		ft_put_error(strerror(errno));


### PR DESCRIPTION
# 概要
termcap対応によりテストツールが使えなくなってしまったのでテストできるように

# 受入条件
内容確認、動作確認（make）

# コメント
- isatty()関数で標準入力が開いているかどうかを見て処理を分けました。
- 一方は今まで通りのminishell_loopです。ターミナルの初期化処理だけinit_minishellから出してminishell_loopの頭に入れました。
- もう一方はget_next_lineを使用するminishell_loop_without_termです。以前のコミットを参考に作りました。
