### PR TITLE
Feature/remaining errors

### DIFF
--- a/includes/minishell_tnishina.h
+++ b/includes/minishell_tnishina.h
@@ -141,7 +141,7 @@ int			ft_remove_escape(t_list *lst);
 char		*ft_get_pathenv(char *s);
 
 /* do_path_command.c */
-void		ft_do_path_command(char **argv, char *command_dir);
+void		ft_do_path_command(char **argv, char **command_dir);
 void		ft_execute_w_environ(char **argv);
 
 /* do_nonpath_command.c */
@@ -200,7 +200,7 @@ void		ft_run_commands(t_command *commands, int *res);
 t_command	*ft_execute_pipeline(t_command *c);
 
 /* execute_builtin.c */
-int			ft_execute_builtin(t_command *c);
+int			ft_execute_builtin(t_bool is_pipe, t_command *c);
 
 /* do_command.c */
 void		ft_do_command(t_command *c);

--- a/ourtest.txt
+++ b/ourtest.txt
@@ -49,3 +49,7 @@ file ; > file
 > file | > file
 < file
 whereis ls | cat -e | cat -e > test
+"$NO"
+exit 0 0 | echo hello
+echo a | $NO_ENV | cat
+echo a | $NO_ENV | echo b

--- a/srcs/do_command.c
+++ b/srcs/do_command.c
@@ -35,9 +35,9 @@ void
 	command_dir = get_command_dir(argv[0]);
 	if (!command_dir)
 		ft_exit_n_free_g_vars(STATUS_GENERAL_ERR);
-	if (argv[0][0] == '/' || argv[0][0] == '.' || !path_env
-		|| !*path_env || *command_dir)
-		ft_do_path_command(argv, command_dir);
+	if (argv[0][0] == '/' || argv[0][0] == '.' || !(argv[0][0])
+		|| !path_env || !*path_env || *command_dir)
+		ft_do_path_command(argv, &command_dir);
 	else
 	{
 		ft_free(&command_dir);

--- a/srcs/do_path_command.c
+++ b/srcs/do_path_command.c
@@ -61,11 +61,17 @@ static void
 }
 
 void
-	ft_do_path_command(char **argv, char *command_dir)
+	ft_do_path_command(char **argv, char **command_dir)
 {
-	if (*command_dir)
-		check_command_dir(argv[0], command_dir);
-	ft_free(&command_dir);
-	execute_path_command(argv);
+	if (*command_dir && **command_dir)
+		check_command_dir(argv[0], *command_dir);
+	ft_free(command_dir);
+	if (!argv[0][0])
+	{
+		ft_put_cmderror(argv[0], COMMAND_NOT_FOUND_ERR_MSG);
+		g_status = STATUS_COMMAND_NOT_FOUND;
+	}
+	else
+		execute_path_command(argv);
 	ft_exit_n_free_g_vars(g_status);
 }

--- a/srcs/execute_builtin.c
+++ b/srcs/execute_builtin.c
@@ -3,7 +3,7 @@
 #include "libft.h"
 
 static int
-	do_builtin_cmd(char **argv)
+	do_builtin_cmd(t_bool is_pipe, char **argv)
 {
 	int	res;
 
@@ -20,12 +20,16 @@ static int
 	else if (!ft_strcmp(argv[0], "env"))
 		res = ft_env(argv);
 	else
+	{
+		if (!is_pipe)
+			ft_putstr_fd(EXIT_PROMPT, STDERR_FILENO);
 		res = ft_exit(argv);
+	}
 	return (res);
 }
 
 int
-	ft_execute_builtin(t_command *c)
+	ft_execute_builtin(t_bool is_pipe, t_command *c)
 {
 	char	**argv;
 	int		res;
@@ -43,7 +47,7 @@ int
 			g_status = 1;
 			return (STOP);
 		}
-		res = do_builtin_cmd(argv);
+		res = do_builtin_cmd(is_pipe, argv);
 		ft_clear_argv(&argv);
 	}
 	ft_restore_fds(c, std_fds);

--- a/srcs/exit.c
+++ b/srcs/exit.c
@@ -4,7 +4,6 @@
 static int
 	exit_with_too_many_args(char **trimmed_arg)
 {
-	ft_putstr_fd(EXIT_PROMPT, STDERR_FILENO);
 	ft_put_cmderror("exit", "too many arguments");
 	g_status = STATUS_GENERAL_ERR;
 	if (*trimmed_arg)
@@ -15,7 +14,6 @@ static int
 static int
 	exit_with_non_numeric(char *arg, char **trimmed_arg)
 {
-	ft_putstr_fd(EXIT_PROMPT, STDERR_FILENO);
 	ft_put_cmderror_with_arg("exit", "numeric argument required", arg);
 	g_status = STATUS_OUT_OF_RANGE_ERR;
 	if (*trimmed_arg)

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -121,11 +121,7 @@ int
 			ft_clear_commands(&commands);
 		}
 		if (res == EXIT || res == EXIT_NON_NUMERIC)
-		{
-			if (res == EXIT)
-				ft_putstr_fd(EXIT_PROMPT, STDERR_FILENO);
 			break ;
-		}
 	}
 	ft_exit_n_free_g_vars(g_status);
 }

--- a/srcs/run_commands.c
+++ b/srcs/run_commands.c
@@ -58,7 +58,7 @@ void
 		{
 			if (ft_is_builtin(c) && !ft_is_pipe(c))
 			{
-				*res = ft_execute_builtin(c);
+				*res = ft_execute_builtin(FALSE, c);
 				if (*res != KEEP_RUNNING)
 					break ;
 				c = c->next;


### PR DESCRIPTION
# 概要
#197 #201 に対応しました

# 受入条件
動作確認、内容確認

# コメント
- #197 については、exitがパイプの中で呼ばれている場合にはexitを表示させないようにフラグで場合分けしています
- #201 についてはc->argsが""のときの条件を追加したのに加え、パイプの中でc->argsが空になるような場合には、標準出力へのパイプのdup2をしないように修正することで実装しています

close #197 
close #201 