### PR TITLE
Feature/rev signal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ SRCS		:= init_minishell.c \
 				replace_env_token.c reconnect_tokens.c replace_q_env.c \
 				run_commands.c execute_pipeline.c execute_builtin.c do_command.c \
 				run_commandline.c \
+				pipe_signal.c \
 				$(HISTDIR)hlist_utils.c \
 				$(UTILDIR)command_utils.c $(UTILDIR)command_errors.c $(UTILDIR)minishell_errors.c \
 				$(UTILDIR)tlist_utils.c $(UTILDIR)split_utils.c $(UTILDIR)utils_tnishina.c $(UTILDIR)utils.c \

--- a/includes/minishell_tnishina.h
+++ b/includes/minishell_tnishina.h
@@ -212,4 +212,8 @@ void		ft_run_commandline(char **av);
 t_command	*ft_convert_line(char **line, t_command **commands);
 t_bool		ft_is_end_with_escape(char *line);
 
+/* pipe_signal.c */
+void		ft_sig_pipe(void);
+void		ft_handle_post_pipe_signal(int signal);
+
 #endif

--- a/srcs/execute_pipeline.c
+++ b/srcs/execute_pipeline.c
@@ -3,21 +3,21 @@
 #include "libft.h"
 
 static void
-	dup_to_stdfd(t_command *c, t_bool pipe_flag[2], int lastpipe[2], int newpipe[2])
+	dup_to_stdfd(t_command *c, t_bool p_flag[2], int last_p[2], int new_p[2])
 {
-	if (pipe_flag[1])
+	if (p_flag[1])
 	{
-		close(lastpipe[1]);
-		if (dup2(lastpipe[0], STDIN_FILENO) < 0)
+		close(last_p[1]);
+		if (dup2(last_p[0], STDIN_FILENO) < 0)
 			ft_exit_n_free_g_vars(STATUS_GENERAL_ERR);
-		close(lastpipe[0]);
+		close(last_p[0]);
 	}
-	if (pipe_flag[0])
+	if (p_flag[0])
 	{
-		close(newpipe[0]);
-		if (c->args && dup2(newpipe[1], STDOUT_FILENO) < 0)
+		close(new_p[0]);
+		if (c->args && dup2(new_p[1], STDOUT_FILENO) < 0)
 			ft_exit_n_free_g_vars(STATUS_GENERAL_ERR);
-		close(newpipe[1]);
+		close(new_p[1]);
 	}
 }
 

--- a/srcs/execute_pipeline.c
+++ b/srcs/execute_pipeline.c
@@ -64,6 +64,7 @@ static void
 	p_flag[0] = ft_is_pipe(c);
 	if (p_flag[0])
 		pipe(newpipe);
+	ft_sig_pipe();
 	pid = fork();
 	if (pid == 0)
 	{

--- a/srcs/pipe_signal.c
+++ b/srcs/pipe_signal.c
@@ -1,0 +1,44 @@
+#include "minishell_tnishina.h"
+#include "minishell_sikeda.h"
+#include "libft.h"
+
+void
+	ft_handle_post_pipe_signal(int signal)
+{
+	if (signal == SIGINT)
+		ft_putstr_fd("\n", STDERR_FILENO);
+	else if (signal == SIGQUIT)
+		ft_putstr_fd("Quit: 3\n", STDERR_FILENO);
+}
+
+static void
+	handle_piped_signal(int signal)
+{
+	if (signal == SIGINT)
+	{
+		if (kill(g_latest_pid, 0) == 0)
+			g_status = 130;
+		else
+			ft_putstr_fd("\n", STDERR_FILENO);
+	}
+	else if (signal == SIGQUIT)
+	{
+		if (kill(g_latest_pid, 0) == 0)
+			g_status = 131;
+	}
+}
+
+void
+	ft_sig_pipe(void)
+{
+	if (signal(SIGINT, handle_piped_signal) == SIG_ERR)
+	{
+		ft_putstr_fd(strerror(errno), STDERR_FILENO);
+		exit(1);
+	}
+	if (signal(SIGQUIT, handle_piped_signal) == SIG_ERR)
+	{
+		ft_putstr_fd(strerror(errno), STDERR_FILENO);
+		exit(1);
+	}
+}

--- a/srcs/run_commands.c
+++ b/srcs/run_commands.c
@@ -37,8 +37,11 @@ static t_bool
 		return (FALSE);
 	if (WIFEXITED(term_status))
 		g_status = WEXITSTATUS(term_status);
+	else if (WIFSIGNALED(term_status))
+		ft_handle_post_pipe_signal(WTERMSIG(term_status));
 	while (wait(NULL) > 0)
 		;
+	ft_sig_post();
 	return (TRUE);
 }
 


### PR DESCRIPTION
# 概要
#204 に対応しました。

# 受入条件
動作確認、内容確認。

# コメント
- 以下のケースをローカルで試してみて、bashと同様の出力になることが確認できています。

1. minishell起動後、`sleep 5`, `sleep 5 | echo a`, `echo a | sleep 5`をそれぞれctrl-Cとctrl-\で停止
2. minishell起動後、もう一回minishellを起動した後に、`sleep 5`, `sleep 5 | echo a`, `echo a | sleep 5`をそれぞれctrl-Cとctrl-\で停止 

close #204 