### PR TITLE
fix #222 redirect SEGV

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ SRCS		:= add_space.c \
 				run_commandline.c \
 				run_commands.c \
 				set_redirection.c \
+				has_env_in_path.c \
 				$(BUILTINDIR)cd/cd.c \
 				$(BUILTINDIR)cd/cd_error.c \
 				$(BUILTINDIR)cd/cd_fullpath.c \

--- a/includes/minishell_tnishina.h
+++ b/includes/minishell_tnishina.h
@@ -47,7 +47,7 @@
 /* redirection parameters */
 
 # define NO_FD_SETTING -1
-# define TOKEN_ERROR -2
+# define GENERAL_ERROR -2
 # define OVER_INT_RANGE -3
 
 /*
@@ -276,7 +276,7 @@ t_bool		ft_is_redirect(char *arg);
 /* utils/minishell_errors.c */
 void		ft_put_error(char *msg);
 void		ft_put_syntaxerror_with_token(char *token);
-void		ft_put_fderror(int fd_from);
+void		ft_put_fderror(int fd_from, t_bool res);
 
 /* utils/minihsell_utils.c */
 void		ft_exit_n_free_g_vars(int exit_status);
@@ -285,6 +285,8 @@ void		ft_exit_n_free_g_vars(int exit_status);
 void		ft_save_fds(t_command *c, int std_fds[3]);
 void		ft_restore_fds(t_command *c, int std_fds[3]);
 t_bool		ft_check_param_error(int fd_from, char *path, char *redirect_op);
+t_bool		ft_is_valid_path(const char *path);
+t_bool		ft_validate_path(t_list *rd, char **path, char *pre_exp, int res);
 
 /* utils/split_utils.c */
 void		ft_free_split(char ***split);
@@ -365,10 +367,10 @@ t_command	*ft_get_last_command(t_command *head);
 t_bool		ft_execute_redirection(int fd, char *op, char *path, int stdfds[3]);
 
 /* replace_env.c */
-int			ft_replace_env(t_list **args, int dq_flag, int eq_flag, int *i);
+int			ft_replace_env(t_list **args, int fl[4], int *i, t_bool is_rd);
 
 /* find_n_replace_env.c */
-int			ft_find_n_replace_env(t_list **args);
+int			ft_find_n_replace_env(t_list **args, t_bool is_redirect);
 
 /* replace_env_tokens.c */
 int			ft_replace_env_token(t_list **args, int *env_pos, int *i);
@@ -414,5 +416,8 @@ int			ft_ms_get_next_line(char **line);
 
 /* handle_signal_w_gnl.c */
 void		ft_sig_prior_w_gnl(void);
+
+/* has_env_in_path.c */
+t_bool		ft_has_env_in_path(char *path);
 
 #endif

--- a/ourtest.txt
+++ b/ourtest.txt
@@ -53,3 +53,9 @@ whereis ls | cat -e | cat -e > test
 exit 0 0 | echo hello
 echo a | $NO_ENV | cat
 echo a | $NO_ENV | echo b
+export TEST='a b'; echo aaa >$TEST
+export TEST='a	b'; echo aaa >$TEST
+200>$NO_ENV
+200000>$NO_ENV
+20000000000000>$NO_ENV
+echo aaa > ""

--- a/srcs/expand_env.c
+++ b/srcs/expand_env.c
@@ -47,26 +47,12 @@ static t_bool
 */
 
 static int
-	handle_non_complete(t_list *l[2], char **pre_expand, int res, t_list **head)
+	handle_non_complete(t_list *l[2], int res, t_list **head)
 {
 	if (res == FAILED)
-	{
-		ft_free(pre_expand);
 		return (FAILED);
-	}
-	else if (l[0] && ft_is_redirect((char *)l[0]->content))
-	{
-		ft_put_cmderror(*pre_expand, AMBIGUOUS_REDIRECT_ERR_MSG);
-		g_ms.status = STATUS_GENERAL_ERR;
-		ft_free(pre_expand);
-		return (REDIRECT_DELETED);
-	}
 	else if (!delete_env(&l[1], head, l[0], res))
-	{
-		ft_free(pre_expand);
 		return (FAILED);
-	}
-	ft_free(pre_expand);
 	return (COMPLETED);
 }
 
@@ -79,7 +65,6 @@ static int
 	expand_list(t_list **head)
 {
 	t_list	*lists[2];
-	char	*pre_expand;
 	int		res;
 
 	if (!(*head))
@@ -89,16 +74,14 @@ static int
 	res = COMPLETED;
 	while (lists[1] && res != FAILED && res != REDIRECT_DELETED)
 	{
-		pre_expand = ft_strdup((char *)lists[1]->content);
-		res = ft_find_n_replace_env(&lists[1]);
+		res = ft_find_n_replace_env(&lists[1], FALSE);
 		if (res == COMPLETED)
 		{
 			lists[0] = lists[1];
 			lists[1] = lists[1]->next;
-			ft_free(&pre_expand);
 		}
 		else
-			res = handle_non_complete(lists, &pre_expand, res, head);
+			res = handle_non_complete(lists, res, head);
 	}
 	return (res);
 }
@@ -107,23 +90,16 @@ int
 	ft_expand_env_var(t_command *c)
 {
 	int	exp_args_res;
-	int	exp_redirect_res;
 
 	if (!c || c->expanded)
 		return (COMPLETED);
 	else
 	{
 		exp_args_res = COMPLETED;
-		exp_redirect_res = COMPLETED;
 		if (c->args)
 			exp_args_res = expand_list(&(c->args));
-		if (c->redirects)
-			exp_redirect_res = expand_list(&(c->redirects));
-		if (exp_args_res == FAILED
-			|| exp_redirect_res == FAILED)
+		if (exp_args_res == FAILED)
 			return (FAILED);
-		else if (exp_redirect_res == REDIRECT_DELETED)
-			return (REDIRECT_DELETED);
 		c->expanded = TRUE;
 		return (COMPLETED);
 	}

--- a/srcs/find_n_replace_env.c
+++ b/srcs/find_n_replace_env.c
@@ -66,7 +66,7 @@ static int
 */
 
 int
-	ft_find_n_replace_env(t_list **args)
+	ft_find_n_replace_env(t_list **args, t_bool is_redirect)
 {
 	int		i;
 	int		fl[4];
@@ -84,7 +84,7 @@ int
 		if (!fl[0] && !fl[3] && ((char *)(*args)->content)[i] == '$'
 			&& !(ft_is_env_name_end(((char *)(*args)->content)[i + 1])))
 		{
-			res = ft_replace_env(args, fl[1], fl[2], &i);
+			res = ft_replace_env(args, fl, &i, is_redirect);
 			if (res == FAILED || res == ENV_DELETED || res == TOKEN_DELETED)
 				return (res);
 		}

--- a/srcs/has_env_in_path.c
+++ b/srcs/has_env_in_path.c
@@ -1,0 +1,86 @@
+#include "minishell_tnishina.h"
+
+/*
+** fl[0]: a flag for single quotations ('\'')
+** fl[1]: a flag for double quotations ('\"')
+** fl[2]: a flag for equal signs ('=')
+** fl[3]: a flag for backslashes ('\\')
+*/
+
+static void
+	check_quotation(char *s, int *i, int fl[4])
+{
+	if (s[*i] == '\'' && !fl[1])
+	{
+		fl[0] = !fl[0];
+		(*i)++;
+	}
+	else if (s[*i] == '\"' && !fl[0])
+	{
+		fl[1] = !fl[1];
+		(*i)++;
+	}
+	else if ((s[*i] == '\'' && fl[1]) || (s[*i] == '\"' && fl[0]))
+		(*i)++;
+}
+
+/*
+** fl[0]: a flag for single quotations ('\'')
+** fl[1]: a flag for double quotations ('\"')
+** fl[2]: a flag for equal signs ('=')
+** fl[3]: a flag for backslashes ('\\')
+*/
+
+static int
+	check_conditions(char *path, int *i, int fl[4])
+{
+	if (path[*i] == '=')
+	{
+		fl[2] = 1;
+		(*i)++;
+		return (CONDITIONS_MET);
+	}
+	else if (!fl[3] && path[*i] == '\\' && !fl[0] && (!fl[1]
+			|| ft_is_escapable_in_dquote(path[(*i) + 1])))
+	{
+		fl[3] = 1;
+		(*i)++;
+		return (CONDITIONS_MET);
+	}
+	else if (!fl[3] && ft_is_quote(path, *i))
+	{
+		check_quotation(path, i, fl);
+		return (CONDITIONS_MET);
+	}
+	return (COMPLETED);
+}
+
+/*
+** fl[0]: a flag for single quotations ('\'')
+** fl[1]: a flag for double quotations ('\"')
+** fl[2]: a flag for equal signs ('=')
+** fl[3]: a flag for backslashes ('\\')
+*/
+
+t_bool
+	ft_has_env_in_path(char *path)
+{
+	int		i;
+	int		fl[4];
+
+	i = 0;
+	ft_memset(fl, 0, sizeof(fl));
+	while (path[i])
+	{
+		if (check_conditions(path, &i, fl) == CONDITIONS_MET)
+			continue ;
+		if (!fl[0] && !fl[3]
+			&& (path[i] == '$'
+				&& !(ft_is_env_name_end(path[i + 1]))))
+			return (TRUE);
+		else
+			i++;
+		fl[3] = 0;
+	}
+	return (FALSE);
+}

--- a/srcs/replace_env.c
+++ b/srcs/replace_env.c
@@ -20,8 +20,15 @@ static t_bool
 	return (res);
 }
 
+/*
+** fl[0]: a flag for single quotations ('\'')
+** fl[1]: a flag for double quotations ('\"')
+** fl[2]: a flag for equal signs ('=')
+** fl[3]: a flag for backslashes ('\\')
+*/
+
 int
-	ft_replace_env(t_list **args, int dq_flag, int eq_flag, int *i)
+	ft_replace_env(t_list **args, int fl[4], int *i, t_bool is_rd)
 {
 	t_bool	has_name;
 	int		env_pos[2];
@@ -36,7 +43,7 @@ int
 	if (j - env_pos[0] == 1 && ((char *)(*args)->content)[j] == '?')
 		j++;
 	env_pos[1] = j;
-	if (dq_flag || (has_name && eq_flag))
+	if (fl[1] || (has_name && fl[2]) || is_rd)
 		return (ft_replace_q_env(((char **)&((*args)->content)), env_pos, i));
 	else
 		return (ft_replace_env_token(args, env_pos, i));

--- a/srcs/replace_q_env.c
+++ b/srcs/replace_q_env.c
@@ -78,7 +78,7 @@ int
 		return (FAILED);
 	if (!combine_strs(content, new, tmp, i))
 		return (FAILED);
-	if (!(*content))
+	if (!(*content) || !ft_strlen(*content))
 		res = ENV_DELETED;
 	else
 		res = COMPLETED;

--- a/srcs/utils/minishell_errors.c
+++ b/srcs/utils/minishell_errors.c
@@ -26,17 +26,20 @@ void
 }
 
 void
-	ft_put_fderror(int fd_from)
+	ft_put_fderror(int fd_from, t_bool res)
 {
 	int	fd;
 
 	fd = STDERR_FILENO;
 	ft_putstr_fd(PRG_NAME, fd);
 	ft_putstr_fd(": ", fd);
-	if (fd_from == -3)
+	if (fd_from == OVER_INT_RANGE)
 		ft_putstr_fd(FD_OOR_MSG, fd);
 	else
 		ft_putnbr_fd(fd_from, fd);
 	ft_putstr_fd(": ", fd);
-	ft_putendl_fd(FD_ERROR_MSG, fd);
+	if (!res)
+		ft_putendl_fd(FD_ERROR_MSG, fd);
+	else
+		ft_putendl_fd(AMBIGUOUS_REDIRECT_ERR_MSG, fd);
 }

--- a/srcs/utils/redirection_utils.c
+++ b/srcs/utils/redirection_utils.c
@@ -1,5 +1,4 @@
 #include "minishell_tnishina.h"
-#include "libft.h"
 
 void
 	ft_save_fds(t_command *c, int std_fds[3])
@@ -33,16 +32,56 @@ void
 }
 
 t_bool
+	ft_is_valid_path(const char *path)
+{
+	while (*path)
+	{
+		if (*path == ' ' || *path == '\t')
+			return (FALSE);
+		path++;
+	}
+	return (TRUE);
+}
+
+t_bool
 	ft_check_param_error(int fd_from, char *path, char *redirect_op)
 {
-	if (fd_from <= TOKEN_ERROR || FD_MAX < fd_from || !redirect_op || !path)
+	t_bool	res;
+
+	res = ft_has_env_in_path(path);
+	if (fd_from <= GENERAL_ERROR || FD_MAX < fd_from || res)
 	{
-		if (fd_from == OVER_INT_RANGE || FD_MAX < fd_from)
-			ft_put_fderror(fd_from);
+		if (fd_from == OVER_INT_RANGE || (FD_MAX < fd_from && !res))
+			ft_put_fderror(fd_from, res);
+		else if (res)
+			ft_put_cmderror(path, AMBIGUOUS_REDIRECT_ERR_MSG);
 		g_ms.status = STATUS_GENERAL_ERR;
 		ft_free(&path);
 		ft_free(&redirect_op);
 		return (FALSE);
+	}
+	return (TRUE);
+}
+
+t_bool
+	ft_validate_path(t_list *rd, char **path, char *pre_exp, int res)
+{
+	if (res == ENV_DELETED)
+		*path = pre_exp;
+	else if (res == COMPLETED)
+	{
+		if (ft_is_valid_path((char *)(rd->next->content)))
+		{
+			ft_free(&pre_exp);
+			*path = ft_strdup((char *)(rd->next->content));
+			if (!*path)
+			{
+				g_ms.status = STATUS_GENERAL_ERR;
+				return (FALSE);
+			}
+		}
+		else
+			*path = pre_exp;
 	}
 	return (TRUE);
 }


### PR DESCRIPTION
# 概要
#222 に対応しました

# 受入条件
動作確認、内容確認

# コメント
- makeで通るようになっているかと思います
- ourtest.txtに関連するテストケースも追加しています
- `echo aaa 2000000000000>$NO_ENV`みたいなケースに対応するためには、ちゃんと構造を変えなくてはならず、c->redirectに含まれている環境変数の展開のタイミングを変更しています

close #222 