### PR TITLE
rename #234 header file

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -1,5 +1,5 @@
-#ifndef MINISHELL_TNISHINA_H
-# define MINISHELL_TNISHINA_H
+#ifndef MINISHELL_H
+# define MINISHELL_H
 
 /*
 ** required header files

--- a/srcs/add_space.c
+++ b/srcs/add_space.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 t_bool
 	add_space_after_redirect(char **l, int *i)

--- a/srcs/builtins/cd/cd.c
+++ b/srcs/builtins/cd/cd.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static t_bool
 	validate_args(const char *args)

--- a/srcs/builtins/cd/cd_error.c
+++ b/srcs/builtins/cd/cd_error.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 void
 	ft_put_cderror_no_current(const int errornum)

--- a/srcs/builtins/cd/cd_fullpath.c
+++ b/srcs/builtins/cd/cd_fullpath.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static int
 	make_current_path_list(t_list **path_list)

--- a/srcs/builtins/cd/cd_path_utils.c
+++ b/srcs/builtins/cd/cd_path_utils.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 char
 	*ft_join_path(const char *path, const char *new)

--- a/srcs/builtins/cd/exec_cd_path.c
+++ b/srcs/builtins/cd/exec_cd_path.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static char
 	*create_new_path(const char *cd_path, const char *path)

--- a/srcs/builtins/cd/get_cd_result.c
+++ b/srcs/builtins/cd/get_cd_result.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static int
 	exec_cd(char **path, const char *args)

--- a/srcs/builtins/echo.c
+++ b/srcs/builtins/echo.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static t_bool
 	has_n_option(const char *args)

--- a/srcs/builtins/env.c
+++ b/srcs/builtins/env.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static void
 	put_enverror_with_option(char *option)

--- a/srcs/builtins/exit.c
+++ b/srcs/builtins/exit.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static int
 	exit_with_too_many_args(char **trimmed_arg)

--- a/srcs/builtins/export.c
+++ b/srcs/builtins/export.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static int
 	stop_with_puterror(const int err)

--- a/srcs/builtins/export_print.c
+++ b/srcs/builtins/export_print.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static void
 	put_env_with_export_syntax(const char *str, const int fd)

--- a/srcs/builtins/export_setenv.c
+++ b/srcs/builtins/export_setenv.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 #ifdef EXPORTTEST
 static void

--- a/srcs/builtins/pwd.c
+++ b/srcs/builtins/pwd.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 int
 	ft_init_pwd(void)

--- a/srcs/builtins/unset.c
+++ b/srcs/builtins/unset.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static t_bool
 	validate_arg(char *arg)

--- a/srcs/create_n_add_command.c
+++ b/srcs/create_n_add_command.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 t_command
 	*ft_get_last_command(t_command *head)

--- a/srcs/do_command.c
+++ b/srcs/do_command.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static char
 	*get_command_dir(char *command)

--- a/srcs/do_nonpath_command.c
+++ b/srcs/do_nonpath_command.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static void
 	set_dir_error(char *command)

--- a/srcs/do_path_command.c
+++ b/srcs/do_path_command.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static void
 	check_command_dir(char *command, char *command_dir)

--- a/srcs/env/env_copy.c
+++ b/srcs/env/env_copy.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 void
 	ft_clear_copied_env(t_list **cpy)

--- a/srcs/env/env_sort.c
+++ b/srcs/env/env_sort.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static int
 	change_first_target_to_char(char *str, char target, char c)

--- a/srcs/env/env_utils.c
+++ b/srcs/env/env_utils.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 char
 	*ft_getenv(const char *name)

--- a/srcs/env/env_utils2.c
+++ b/srcs/env/env_utils2.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 char
 	*ft_extract_envname_from_str(const char *str)

--- a/srcs/env/init_env.c
+++ b/srcs/env/init_env.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 /* return zero when overflow and check char after number */
 static int

--- a/srcs/execute_builtin.c
+++ b/srcs/execute_builtin.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static int
 	do_builtin_cmd(t_bool is_pipe, char **argv)

--- a/srcs/execute_pipeline.c
+++ b/srcs/execute_pipeline.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static void
 	dup_to_stdfd(t_command *c, t_bool p_flag[2], int last_p[2], int new_p[2])

--- a/srcs/execute_redirection.c
+++ b/srcs/execute_redirection.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static t_bool
 	append_redirect_out(int fd_from, char *path, int std_fds[3])

--- a/srcs/expand_env.c
+++ b/srcs/expand_env.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static t_bool
 	create_empty_lst(t_list **tokens, t_list **head)

--- a/srcs/extract_redirect.c
+++ b/srcs/extract_redirect.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static void
 	update_redirects(t_command *c, t_list **current, t_list *prev)

--- a/srcs/find_n_replace_env.c
+++ b/srcs/find_n_replace_env.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 /*
 ** fl[0]: a flag for single quotations ('\'')

--- a/srcs/get_next_line.c
+++ b/srcs/get_next_line.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 void
 	ft_free_strs(char **line, char **fd_array)

--- a/srcs/get_pathenv.c
+++ b/srcs/get_pathenv.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static void
 	add_pwd_front(char **path_env)

--- a/srcs/handle_signal.c
+++ b/srcs/handle_signal.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static void
 	handle_prior_signal(int signal)

--- a/srcs/handle_signal_w_gnl.c
+++ b/srcs/handle_signal_w_gnl.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static void
 	handle_prior_signal(int signal)

--- a/srcs/has_env_in_path.c
+++ b/srcs/has_env_in_path.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 /*
 ** fl[0]: a flag for single quotations ('\'')

--- a/srcs/heredocument.c
+++ b/srcs/heredocument.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static void
 	free_n_close(char **line, int fd, t_bool should_exit)

--- a/srcs/history/hlist_utils.c
+++ b/srcs/history/hlist_utils.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static t_history
 	*new_history(const char *line, const size_t len,

--- a/srcs/init_minishell.c
+++ b/srcs/init_minishell.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 #ifdef WITH_GNL
 int

--- a/srcs/is_delimiter_or_quote.c
+++ b/srcs/is_delimiter_or_quote.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 t_bool
 	ft_is_delimiter(char c)

--- a/srcs/make_command.c
+++ b/srcs/make_command.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static t_bool
 	is_valid_rediret(t_command *c, t_list *current)

--- a/srcs/make_token.c
+++ b/srcs/make_token.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static int
 	exit_w_quotation_error(char *cpy, t_list **tokens)

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 t_bool
 	ft_is_end_with_escape(char *line)

--- a/srcs/minishell_w_gnl.c
+++ b/srcs/minishell_w_gnl.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 #ifdef WITH_GNL
 static void

--- a/srcs/ms_get_next_line.c
+++ b/srcs/ms_get_next_line.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static t_bool
 	erace_input(char *s)

--- a/srcs/pipe_signal.c
+++ b/srcs/pipe_signal.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 void
 	ft_handle_post_pipe_signal(int signal)

--- a/srcs/reconnect_tokens.c
+++ b/srcs/reconnect_tokens.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static int
 	handle_multi_tokens(t_list *tokens, char *new[3], t_list **args, int *i)

--- a/srcs/replace_env.c
+++ b/srcs/replace_env.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static t_bool
 	has_valid_name(const char *content)

--- a/srcs/replace_env_token.c
+++ b/srcs/replace_env_token.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static char
 	*convert_env(char *new[3])

--- a/srcs/replace_q_env.c
+++ b/srcs/replace_q_env.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 void
 	ft_free_all_chars(char **env, char *tmp[2], char *new[3])

--- a/srcs/run_commandline.c
+++ b/srcs/run_commandline.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static void
 	get_commandline_input(char *input, t_command **commands)

--- a/srcs/run_commands.c
+++ b/srcs/run_commands.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 t_bool
 	ft_is_pipe(t_command *c)

--- a/srcs/set_rd_params.c
+++ b/srcs/set_rd_params.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static int
 	get_fd(char *arg)

--- a/srcs/set_redirection.c
+++ b/srcs/set_redirection.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 void
 	ft_free_n_update_params(t_list **rd, char **op, char **path)

--- a/srcs/termcaps/edit_term.c
+++ b/srcs/termcaps/edit_term.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 void
 	ft_put_line(const char *pre_line, size_t len, t_bool is_heredoc)

--- a/srcs/termcaps/edit_term_history.c
+++ b/srcs/termcaps/edit_term_history.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static void
 	adjust_start_row(t_bool is_heredoc)

--- a/srcs/termcaps/get_line.c
+++ b/srcs/termcaps/get_line.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static int
 	init_input_and_position(void)

--- a/srcs/termcaps/handle_keys.c
+++ b/srcs/termcaps/handle_keys.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static int
 	handle_keys(const char *buf, size_t *allocated, t_bool is_heredoc)

--- a/srcs/termcaps/init_term.c
+++ b/srcs/termcaps/init_term.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 static int
 	get_definition_from_termcap(void)

--- a/srcs/termcaps/term_utils.c
+++ b/srcs/termcaps/term_utils.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 int
 	ft_putchar(int c)

--- a/srcs/utils/command_errors.c
+++ b/srcs/utils/command_errors.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 void
 	ft_do_command_err(char *c)

--- a/srcs/utils/command_utils.c
+++ b/srcs/utils/command_utils.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 char
 	*ft_get_cmd_option(char *option, const char *arg)

--- a/srcs/utils/expand_utils.c
+++ b/srcs/utils/expand_utils.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 t_bool
 	ft_is_space(char *l, int i, int *fl)

--- a/srcs/utils/free_utils.c
+++ b/srcs/utils/free_utils.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 void
 	ft_clear_argv(char ***argv)

--- a/srcs/utils/make_command_utils.c
+++ b/srcs/utils/make_command_utils.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 #include "libft.h"
 
 static void

--- a/srcs/utils/minishell_errors.c
+++ b/srcs/utils/minishell_errors.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 void
 	ft_put_error(char *msg)

--- a/srcs/utils/minishell_utils.c
+++ b/srcs/utils/minishell_utils.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 void
 	ft_exit_n_free_g_vars(int exit_status)

--- a/srcs/utils/redirection_utils.c
+++ b/srcs/utils/redirection_utils.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 void
 	ft_save_fds(t_command *c, int std_fds[3])

--- a/srcs/utils/split_utils.c
+++ b/srcs/utils/split_utils.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 void
 	ft_free_split(char ***split)

--- a/srcs/utils/str_utils.c
+++ b/srcs/utils/str_utils.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 char
 	*ft_strndup_append_null(const char *s, size_t n)

--- a/srcs/utils/tlist_utils.c
+++ b/srcs/utils/tlist_utils.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 void
 	ft_lstdelend(t_list **lst, void (*del)(void*))

--- a/srcs/utils/typerange_utils.c
+++ b/srcs/utils/typerange_utils.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 int
 	ft_isover_intrange(char *s)

--- a/srcs/utils/utils.c
+++ b/srcs/utils/utils.c
@@ -1,4 +1,4 @@
-#include "minishell_tnishina.h"
+#include "minishell.h"
 
 void
 	*ft_realloc(void *original, size_t size, size_t original_size)

--- a/test/test_builtin.h
+++ b/test/test_builtin.h
@@ -1,7 +1,7 @@
 #ifndef TEST_BUILTIN_H
 # define TEST_BUILTIN_H
 
-# include "minishell_tnishina.h"
+# include "minishell.h"
 
 /* test_init.c */
 int	test_init_minishell(void);


### PR DESCRIPTION
# 概要
issue #234 headerファイル名を簡潔に

# 受入条件
内容確認、コンパイル、norm

# コメント
- ヘッダーファイル名からログイン 名を取り除きました
- 一括置換してminishell.hのインクルードガードだけ手作業で変えました

close #234