### PR TITLE
delete #240 implementations regarding curly-brace handing

### DIFF
--- a/srcs/replace_q_env.c
+++ b/srcs/replace_q_env.c
@@ -24,14 +24,8 @@ t_bool
 {
 	int	p[2];
 
-	if (content[env_pos[0] + 1] != '{')
-		p[0] = env_pos[0] + 1;
-	else
-		p[0] = env_pos[0] + 2;
-	if (content[env_pos[0] + 1] == '{' && content[env_pos[1]] == '}')
-		p[1] = env_pos[1] + 1;
-	else
-		p[1] = env_pos[1];
+	p[0] = env_pos[0] + 1;
+	p[1] = env_pos[1];
 	new[0] = ft_substr(content, 0, env_pos[0]);
 	new[1] = ft_substr(content, p[0], env_pos[1] - p[0]);
 	new[2] = ft_strdup(content + p[1]);


### PR DESCRIPTION
# 概要
#240への対応をしました

# 受入条件
内容確認、動作確認、norm確認、下記コメントの対応方針確認

# コメント
遅くなってすいません。あの後、いろいろ試してみたのですが、結論から言うと、ご指摘頂いた部分は実装しなくてもよいのではないか、という風に考えを変えました。もし`'`または`"`の直前に`$`が来た場合に`$`が消えるのが環境変数の展開に起因するものであるならば、下記のコマンドでも`$`が消えて然るべきだと思うのですが、この場合は消えません。(`$`自体はダブルクオーテーションの中にあるので評価されるべきだが、評価されていない。)
```
bash-3.2$ echo "$'USER'"
$'USER'
```
なので、今回の$の処理についても、「**変数名に使用できない文字 (例: !, #, $等)が`$`の次に指定された場合には、`$`を環境変数を変換するオペレータとして認識せず、文字としての`$`として認識する (但し、課題文で明示的に対応を求められている`$?`については例外)**」という整理で、今のままの実装で説明したほうが筋が通るのではないかと思うのですがいかがでしょうか？

一旦は、以上を踏まえて、既に実装上効力を失っていたものの残っていた波括弧関連の処理を行っていた部分を削除しました。

close #240 