### PR TITLE
fix #245 ft_get_line segmentation fault

### DIFF
--- a/srcs/termcaps/get_line.c
+++ b/srcs/termcaps/get_line.c
@@ -28,7 +28,7 @@ int
 		return (GNL_ERROR);
 	*line = NULL;
 	if (init_input_and_position() == GNL_ERROR)
-		return (GNL_SUCCESS);
+		return (GNL_ERROR);
 	ret = ft_handle_keys_loop(is_heredoc);
 	tcsetattr(STDIN_FILENO, TCSANOW, &g_ms.origin_term);
 	if (0 <= ret)


### PR DESCRIPTION
# 概要
issued #245 guacamoleでのコピペ時セグフォ解消

# コメント
ペーストしたらセグフォしないようにしました。
セグフォはしないのですが以下のような動作をしており、ペースト操作に対応はできていないです。
- zshからminishellを起動した場合、minishellが終了
- bashからminishellを起動した場合、入力した文字が表示されず違う文字が表示される

close #245 